### PR TITLE
Docs review

### DIFF
--- a/packages/ignition/content-collections.ts
+++ b/packages/ignition/content-collections.ts
@@ -167,7 +167,7 @@ function onBeforeSaveCollectionCommon(
         return docs[key][locale];
       };
 
-      const newDoc = { ...data, group, filePath: _meta.filePath };
+      const newDoc = { ...data, group, enslug, filePath: _meta.filePath };
 
       let doc = getObject();
       if (isComponent) {

--- a/packages/ignition/src/app/components/documentation/sidebar-left.tsx
+++ b/packages/ignition/src/app/components/documentation/sidebar-left.tsx
@@ -87,7 +87,7 @@ export const SidebarLeft = ({ lang }: PropsWithLang) => {
                 : docs.filter(
                     (doc: any) =>
                       doc[1][lang].group === mainDocEnSlug &&
-                      doc[1][lang].group != doc[1][lang].slug
+                      doc[1][lang].group != doc[1][lang].enslug
                   );
             return (
               mainDoc && (

--- a/packages/ignition/src/app/components/usage/styling/index.tsx
+++ b/packages/ignition/src/app/components/usage/styling/index.tsx
@@ -236,7 +236,7 @@ const StateManagement = async ({
         </CodeSample>
       </Wrapper>
       <Wrapper>
-        <MdxPartial lang={lang} slug={"styling/styling-cursor"} path="docs" />
+        <MdxPartial lang={lang} slug={"styling/styling-filters"} path="docs" />
         <GridContainer>
           <div className="mx-auto flex justify-center gap-6 my-8">
             <Icon className="size-16 md:size-20 lg:size-32 blur" />

--- a/packages/ignition/src/app/locales/docs/usage/adding.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/adding.en.mdx
@@ -14,7 +14,7 @@ import RocketIconsText, {
 # Adding Icons
 Adding and using icons from <RocketIconsText /> on your application.
 
-_If your are new here or even doesn't have the <RocketIconsText /> installed, you might take a took on [Getting started](./getting-started) before starting._
+_If your are new here or just don't have <RocketIconsText /> installed, you might take a took at [Getting started](./getting-started) before starting._
 <br />
 Using the [icons library](../icons), find the icon you need.  
 An icon is nothing more than a React component, so knowing the name of the component and the sub-package where it is located, you just need to import it.

--- a/packages/ignition/src/app/locales/docs/usage/adding.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/adding.pt-br.mdx
@@ -16,7 +16,7 @@ Adicionando e usando ícones do <RocketIconsText /> em sua aplicação.
 
 _Se você é novo aqui ou ainda não tem o <RocketIconsText /> instalado, talvez você queira dar uma olhada nos [Primeiros Passos](./primeiros-passos) antes de começar._
 <br />
-Usando nossa biblioteca de [ícones](../icons), encontre o ícone que você precisa.   
+Usando nossa [biblioteca de ícones](../icons), encontre o ícone que você precisa.   
 Um ícone nada mais é do que um componente React, então sabendo o nome do componente e do sub pacote onde ele se encontra, você só precisa importá-lo.
 <br />
 Vamos usar como exemplo o componente `RcRocketIcon` que se encontra no sub pacote chamado `rc`.  

--- a/packages/ignition/src/app/locales/docs/usage/components/adding-including.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/adding-including.en.mdx
@@ -7,5 +7,5 @@ order: 5
 activeSelector: group-has-[.docs-adding]:active-content
 ---
 
-Once you get the component imported, you just need to add it anywhere in the code where it is necessary
+Once you get the component imported, you just need to add it anywhere in the code where it is necessary.
 <br />

--- a/packages/ignition/src/app/locales/docs/usage/components/adding-next.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/adding-next.en.mdx
@@ -11,11 +11,11 @@ import RocketIconsText, {
   RocketIconsTextDefault,
 } from "@/components/rocketicons-text";
 
-That is all you need adding an icon to your project.
+That is all you need to add an icon to your project.
 <br />
 Now that you already have the icon, you will most likely want to style it because,
-after the possibility that the <RocketIconsTextDefault /> brings in sharing code between
-Web and Mobile applications, the ease of adapting the appearance and behavior of the icon to
+after the possibility that <RocketIconsTextDefault /> brings in sharing code between
+Web and Mobile applications, the ease of customizing the appearance and behavior of the icon to
 your project is the most powerful functionality of this tool.
 <br />
 You can find a few links to help you out on this task below:

--- a/packages/ignition/src/app/locales/docs/usage/components/adding-next.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/adding-next.pt-br.mdx
@@ -14,7 +14,7 @@ import RocketIconsText, {
 Isso é tudo que você precisa para adicionar um ícone no seu projeto.
 <br />
 Agora que você já tem o ícone, muito provalvemente você vai querer estilizá-lo, porque, depois da possibilidade que
-o <RocketIconsTextDefault /> traz entre compartilhar código entre aplicações Web e Mobile, a facilidade de adequar
+o <RocketIconsTextDefault /> traz entre compartilhar código entre aplicações Web e Mobile, a facilidade de personalizar
 a aparência e o comportamento do ícone ao seu projeto, é a funcionalidade mais poderosa dessa ferramenta.
 <br />
 Então seguem alguns links que podem te ajudar nessa tarefa:

--- a/packages/ignition/src/app/locales/docs/usage/components/colors-defaults.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/colors-defaults.en.mdx
@@ -10,5 +10,5 @@ activeSelector: group-has-[.docs-colors]:active-content
 ### Default color palette
 
 Icons are available in all of Tailwind's default color palette and shares the colors configuration.  
-Follow [the official color customization documation](https://tailwindcss.com/docs/customizing-colors)
+Follow [the official color customization documentation](https://tailwindcss.com/docs/customizing-colors)
 to add your customized palette.

--- a/packages/ignition/src/app/locales/docs/usage/components/dark-mode-action.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/dark-mode-action.pt-br.mdx
@@ -10,6 +10,6 @@ activeSelector: group-has-[.docs-dark-mode]:active-content
 ## Em ação
 ### Uso da variante dark
 
-Use a variante `dark:` para definir estilos no mode escuro.
+Use a variante `dark:` para definir estilos no modo escuro.
 
-> Mude o tema da página e veja o que acontece
+> Mude o tema da página e veja o que acontece.

--- a/packages/ignition/src/app/locales/docs/usage/components/responsive-design-explanation.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/responsive-design-explanation.en.mdx
@@ -7,6 +7,6 @@ order: 6
 activeSelector: group-has-[.docs-responsive-design]:active-content
 ---
 
-The example above works using the Tailwind breakpoints, including an arbitrary one, customizing the design for different screen sizes.
+The example above works using the Tailwind breakpoints, including an arbitrary one using `md-[arbitrary-value]`, customizing the design for different screen sizes.
 
 We’ve only used few breakpoint in this example, but you could easily customize this component at other sizes using the `lg`, `xl`, or `2xl` responsive prefixes as well.

--- a/packages/ignition/src/app/locales/docs/usage/components/responsive-design-explanation.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/responsive-design-explanation.pt-br.mdx
@@ -7,6 +7,6 @@ order: 6
 activeSelector: group-has-[.docs-responsive-design]:active-content
 ---
 
-O exemplo acima funciona usando breakpoints do Tailwind, mesmo que seja arbitrário, customizando o desing para diferentes tamanhos de telas.
+O exemplo inclui breakpoints que são padrões no Tailwind e um exemplo configurado arbitrariamente usando `md-[valor-arbitrario]`, customizando o desing para diferentes tamanhos de telas.
 
 Só usamos alguns breakpoints nesse examplo, mas você pode facilmente customizar esse componente para outros tamanhos usando prefixos como `lg`, `xl`, or `2xl`.

--- a/packages/ignition/src/app/locales/docs/usage/components/responsive-design-explanation.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/responsive-design-explanation.pt-br.mdx
@@ -7,6 +7,6 @@ order: 6
 activeSelector: group-has-[.docs-responsive-design]:active-content
 ---
 
-O exemplo acima funciona usando breakpoints do Tailwind, incluindo um com valor arbitrário, customizando o desing para dirente tamanhos de telas.
+O exemplo acima funciona usando breakpoints do Tailwind, mesmo que seja arbitrário, customizando o desing para diferentes tamanhos de telas.
 
 Só usamos alguns breakpoints nesse examplo, mas você pode facilmente customizar esse componente para outros tamanhos usando prefixos como `lg`, `xl`, or `2xl`.

--- a/packages/ignition/src/app/locales/docs/usage/components/sizing-tw-hw.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/sizing-tw-hw.pt-br.mdx
@@ -8,4 +8,4 @@ activeSelector: group-has-[.docs-sizing-elements]:active-content
 ---
 
 ### Utilizando altura and largura
-Use os utillitários `h-*` combinado com `w-*` para controlar as dimensões do ícone. Abaixo você encontrará alguns exemplos de como utilizá-los, mas para uma lista completa das opções disponíveis, veja a documentação oficial [altura](https://tailwindcss.com/docs/height) e [largura](https://tailwindcss.com/docs/width) do Tailwind.
+Use os utillitários `h-*` combinado com `w-*` para controlar as dimensões do ícone. Abaixo você encontrará alguns exemplos de como utilizá-los, mas para uma lista completa das opções disponíveis, veja a documentação oficial sobre [altura](https://tailwindcss.com/docs/height) e [largura](https://tailwindcss.com/docs/width) do Tailwind.

--- a/packages/ignition/src/app/locales/docs/usage/components/sizing-tw-sizes.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/sizing-tw-sizes.pt-br.mdx
@@ -10,4 +10,4 @@ activeSelector: group-has-[.docs-sizing-elements]:active-content
 ## Usando utilitários do Tailwind
 ### Usando sizes
 
-Utilize os utilitários `size-*` para definir o tamanho de um ícone. Abaixo você encontrará alguns exemplos de como utilizá-los, mas para uma lista completa das opções disponíveis, veja a documentação oficial [tamanhos](https://tailwindcss.com/docs/size) do Tailwind.
+Utilize os utilitários `size-*` para definir o tamanho de um ícone. Abaixo você encontrará alguns exemplos de como utilizá-los, mas para uma lista completa das opções disponíveis, veja a documentação oficial sobre [tamanhos](https://tailwindcss.com/docs/size) do Tailwind.

--- a/packages/ignition/src/app/locales/docs/usage/components/state-management-order.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/state-management-order.en.mdx
@@ -10,7 +10,7 @@ activeSelector: group-has-[.docs-state-management]:active-content
 #### [First, last, odd, and even](https://tailwindcss.com/docs/hover-focus-and-other-states#first-last-odd-and-even)
 Using selectors
 <br />
-__Not available for React Native__. _Learn more on [NativeWind](https://www.nativewind.dev/core-concepts/states) official documentation._
+__Not available for React Native__. _Learn more on the [NativeWind](https://www.nativewind.dev/core-concepts/states) official documentation._
 <br />
 Style an icon when it is the first-child or last-child using the first and last modifiers:
 

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-animate.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-animate.en.mdx
@@ -7,8 +7,8 @@ order: 5
 activeSelector: group-has-[.docs-styling]:active-content
 ---
 
-### Default color palette
+#### [Animations](https://tailwindcss.com/docs/animation)
+Animations and transitions can be used with icons,
+but this functionality is only available for React.
 
-Icons are available in all of Tailwind's default color palette and shares the colors configuration.  
-Follow [the official color customization documation](https://tailwindcss.com/docs/customizing-colors)
-to add your customized palette.
+**React Native has some limited features**. _See the official documentation of [NativeWind](https://www.nativewind.dev/core-concepts/states) for more information._

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-bg.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-bg.en.mdx
@@ -9,4 +9,4 @@ activeSelector: group-has-[.docs-styling]:active-content
 
 ### Defining background
 
-Use the [Tailwind utilities](https://tailwindcss.com/docs/background-attachment) defining the icons background.
+Use the [Tailwind utilities](https://tailwindcss.com/docs/background-attachment) to set the icons background.

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-border-s.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-border-s.en.mdx
@@ -9,4 +9,4 @@ activeSelector: group-has-[.docs-styling]:active-content
 
 ## Borders
 #### [Border Style](https://tailwindcss.com/docs/border-style)
-You can define the border style
+You can define the border style.

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-border-s.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-border-s.pt-br.mdx
@@ -9,4 +9,4 @@ activeSelector: group-has-[.docs-styling]:active-content
 
 ## Bordas
 #### [Estilo da borda](https://tailwindcss.com/docs/border-style)
-Definindo estilo das bordas
+Definindo estilo das bordas.

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-border-w.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-border-w.en.mdx
@@ -9,4 +9,4 @@ activeSelector: group-has-[.docs-styling]:active-content
 
 ## Border
 #### [Border width](https://tailwindcss.com/docs/border-width)
-You can define the border width
+You can define the border width.

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-border.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-border.en.mdx
@@ -15,4 +15,4 @@ import RocketIconsText, {
 Every border utility should work with no problems on <RocketIconsText />.
 <br />
 #### [Border Radius](https://tailwindcss.com/docs/border-radius)
-You can define the border radius
+You can define the border radius.

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-cursor.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-cursor.en.mdx
@@ -8,4 +8,4 @@ activeSelector: group-has-[.docs-styling]:active-content
 ---
 
 #### [Cursor](https://tailwindcss.com/docs/cursor)
-Use cursor on icons
+Use cursor on icons.

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-cursor.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-cursor.pt-br.mdx
@@ -8,5 +8,5 @@ activeSelector: group-has-[.docs-styling]:active-content
 ---
 
 #### [Cursor](https://tailwindcss.com/docs/cursor)
-Definindo cursores nos ícones
+Definindo cursores nos ícones.
 

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-effects.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-effects.pt-br.mdx
@@ -9,4 +9,4 @@ activeSelector: group-has-[.docs-styling]:active-content
 
 #### [Efeitos](https://tailwindcss.com/docs/box-shadow)
 Efeitos como [sombras](https://tailwindcss.com/docs/box-shadow), [opacidade](https://tailwindcss.com/docs/opacity)
-e [mistura](https://tailwindcss.com/docs/mix-blend-mode) podem ser usados com ícones
+e [mistura](https://tailwindcss.com/docs/mix-blend-mode) podem ser usados com ícones.

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-filters.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-filters.en.mdx
@@ -8,6 +8,6 @@ activeSelector: group-has-[.docs-styling]:active-content
 ---
 
 #### [Filters](https://tailwindcss.com/docs/blur)
-Filters and icons
+Filters and icons.
 
-*NativeWind doesn't support filters,  tros logo essa funcionalidade não está disponível para React Native*
+*NativeWind doesn't support filters, therefore this functionality isn't available for React Native."*

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-filters.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-filters.pt-br.mdx
@@ -8,6 +8,6 @@ activeSelector: group-has-[.docs-styling]:active-content
 ---
 
 #### [Filtros](https://tailwindcss.com/docs/blur)
-Filtros e ícones
+Filtros e ícones.
 
-*NativeWind doesn't support filters, therefore this functionality isn't available for React Native."*
+*NativeWind doesn't support filters, logo essa funcionalidade não está disponível para React Native*

--- a/packages/ignition/src/app/locales/docs/usage/components/styling-transform.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/components/styling-transform.en.mdx
@@ -8,7 +8,7 @@ activeSelector: group-has-[.docs-styling]:active-content
 ---
 
 #### [Transforms](https://tailwindcss.com/docs/scale)
-Using tranforms
+Using tranforms.
 
 _Learn more about compatibility on the [NativeWind](https://www.nativewind.dev/core-concepts/states) official documentation._
 

--- a/packages/ignition/src/app/locales/docs/usage/dark-mode.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/dark-mode.en.mdx
@@ -13,6 +13,6 @@ import RocketIconsText, {
 ## Usage
 # How to Enable Dark Mode
 
-Use <RocketIconsText /> to style icons on dark mode.
+Using <RocketIconsText /> to style icons on dark mode.
 
 You can style icons differently when dark mode is enabled.

--- a/packages/ignition/src/app/locales/docs/usage/responsive-design.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/responsive-design.pt-br.mdx
@@ -11,4 +11,4 @@ activeSelector: group-has-[.docs-design-responsivo]:active-content
 
 Todos os utilitários podem ser aplicados condicionalmente em diferentes breakpoints, criando interfaces completamente adaptivas.
 
-Se você não está familiarizado com os breakpoints e variantes disponíveis no Tailwind, recomendamos dar uma checada na [documentação](https://tailwindcss.com/docs/responsive-design).
+Se você não está familiarizado com os breakpoints e variantes disponíveis no Tailwind, recomendamos dar uma checada na [documentação oficial](https://tailwindcss.com/docs/responsive-design).

--- a/packages/ignition/src/app/locales/docs/usage/state-management.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/state-management.en.mdx
@@ -11,7 +11,7 @@ activeSelector: group-has-[.docs-state-management]:active-content
 
 How style icons on hover, focus, and more.
 <br />
-**The state support on React Native is not complete**. _Learn more at [NativeWind](https://www.nativewind.dev/core-concepts/states) documentation._
+**The state support on React Native is not complete**. _Learn more at the [NativeWind](https://www.nativewind.dev/core-concepts/states) documentation._
 <br />
-The modifiers can be applied conditionally by adding them to the beginning of the class name that describes the condition you want to target.   
+The modifiers can be applied conditionally by adding them to the beginning of the class name that describes the condition you want to target.  
 For example, to apply the `border-slate-600` on hover, use `hover:border-slate-600`:

--- a/packages/ignition/src/app/locales/docs/usage/usage.en.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/usage.en.mdx
@@ -6,16 +6,26 @@ order: 0
 activeSelector: group-has-[.docs-usage]:active-content
 ---
 
-# usage
+import RocketIconsText, {
+  RocketIconsTextDefault,
+} from "@/components/rocketicons-text";
 
-First, you need to import the component:
+## Usage
+# Using Rocketicons
+The icon library for React and React Native, empowered by Tailwind
 
-```tsx
-import { RcRocketIcon } from "rocketicons/rc";
-```
+<RocketIconsText /> is an icon library as part of a solution that enables code written in React to run
+seamlessly on both Web and Mobile platforms, without alterations, saving resources and development time,
+allowing the focus to be directed towards what matters. Your application!
+<br />
+As developers who are fans of Tailwind, it was a natural process to leverage this powerful framework to give
+icons a significant level of personalization and customization.
 
-Then, you can use it in your component:
+> I remember being amazed when I understood how Tailwind works, and although I have no affiliation with the
+> company, this work is a tribute to the contribution they've brought to us devs.
+> It's a way of saying, thank you very much!"
 
-```tsx
-<RocketIconsText />
-```
+It was fun to see all that we could accomplish with icons integrated with Tailwind, and we hope you enjoy it as much as we do.
+<br />
+If you haven't installed the package yet, [Getting Started](./getting-started) can be a good way to begin.  
+If you're already set up, let's start [adding icons](./adding-icons).

--- a/packages/ignition/src/app/locales/docs/usage/usage.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/usage.pt-br.mdx
@@ -1,21 +1,32 @@
 ---
-title: Usando o RocketIcons
-description: Documentation for RocketIcons
+title: Usando o Rocketicons
+description: Usando Rocketicons e onde ele pode te ajudar
 slug: usando
 order: 0
 activeSelector: group-has-[.docs-usando]:active-content
 ---
 
-# Como usar
+import RocketIconsText, {
+  RocketIconsTextDefault,
+} from "@/components/rocketicons-text";
 
-Primeiro, você precisa importar o componente:
+## Usando
+# Usando o Rocketicons
+A biblioteca de ícones para React e React Native, com o poder do Tailwind
 
-```tsx
-import { RcRocketIcon } from "rocketicons/rc";
-```
+O <RocketIconsText /> é uma biblioteca de ícones como parte de uma solução que possibilita códigos escritos em React
+rodem tanto na Web quanto no Mobile, sem alterações, economizando recursos e tempo de desenvolvimento, possibilitando que
+o foco seja direcionado ao que importa. A sua aplicação!
+<br />
+Como desenvolvedores fãs do Tailwind, foi uma processo natural usar esse poderoso framework para entregar ao ícones um grande
+poder de personalização e customização.
 
-Então, você pode usar o componente assim:
+> Lembro de ter ficado maravilhado quando entendi o funcionando do Tailwind e apesar de não ter nenhuma ligação com a empresa
+> esse trabalho é um tributo a contribuição que eles trouxeram para nós devs.
+> É uma forma de dizer, muito obrigado!
 
-```tsx
-<RocketIconsText />
-```
+Foi divertido ver tudo o que conseguimos fazer com os ícones integrados com o Tailwind e esperamos que vocês gostem tanto quanto nós.
+<br />
+Se ainda não tem o pacote instalado, os [Primeiros Passos](./primeiros-passos) podem ser um bom caminho para começar.
+Caso já tenha tudo pronto, vamos começar a [adicionar ícones](./adicionando-icones).
+

--- a/packages/ignition/src/app/locales/docs/usage/usage.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/usage.pt-br.mdx
@@ -18,15 +18,16 @@ O <RocketIconsText /> é uma biblioteca de ícones como parte de uma solução q
 rodem tanto na Web quanto no Mobile, sem alterações, economizando recursos e tempo de desenvolvimento, possibilitando que
 o foco seja direcionado ao que importa. A sua aplicação!
 <br />
-Como desenvolvedores fãs do Tailwind, foi uma processo natural usar esse poderoso framework para entregar ao ícones um grande
+Como desenvolvedores fãs do Tailwind, foi um processo natural usar esse poderoso framework para dar aos ícones um grande
 poder de personalização e customização.
 
-> Lembro de ter ficado maravilhado quando entendi o funcionando do Tailwind e apesar de não ter nenhuma ligação com a empresa
+> Lembro de ter ficado maravilhado quando entendemos o funcionando do Tailwind e apesar de não ter nenhuma ligação com a empresa
 > esse trabalho é um tributo a contribuição que eles trouxeram para nós devs.
 > É uma forma de dizer, muito obrigado!
 
 Foi divertido ver tudo o que conseguimos fazer com os ícones integrados com o Tailwind e esperamos que vocês gostem tanto quanto nós.
 <br />
 Se ainda não tem o pacote instalado, os [Primeiros Passos](./primeiros-passos) podem ser um bom caminho para começar.
+
 Caso já tenha tudo pronto, vamos começar a [adicionar ícones](./adicionando-icones).
 

--- a/packages/ignition/src/app/locales/docs/usage/usage.pt-br.mdx
+++ b/packages/ignition/src/app/locales/docs/usage/usage.pt-br.mdx
@@ -21,7 +21,7 @@ o foco seja direcionado ao que importa. A sua aplicação!
 Como desenvolvedores fãs do Tailwind, foi um processo natural usar esse poderoso framework para dar aos ícones um grande
 poder de personalização e customização.
 
-> Lembro de ter ficado maravilhado quando entendemos o funcionando do Tailwind e apesar de não ter nenhuma ligação com a empresa
+> Lembro de ter ficado maravilhado quando entendi o funcionando do Tailwind e apesar de não ter nenhuma ligação com a empresa
 > esse trabalho é um tributo a contribuição que eles trouxeram para nós devs.
 > É uma forma de dizer, muito obrigado!
 


### PR DESCRIPTION
Documentation review. A few points to consider:

- Customizar -> Personalizar?
- Utilitários -> Classes?
- Absolute links vs vscode lint
- Links from usage to getting-started are relative to the root
- Some titles have hidden links. Is this intentional?
- Duplicated cursor section on Styling page. Should it be filters?

Also, the menu bug was fixed on this branch.