### PR TITLE
fix(icons): correct handling of tailwind prefix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 packages/tailwind/src/index.native.test.css linguist-generated
 packages/tailwind/src/index.test.css linguist-generated
+packages/tailwind/src/index.prefixed.test.css linguist-generated

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 **/*mdx
 packages/tailwind/src/index.test.css
+packages/tailwind/src/index.prefixed.test.css
 packages/tailwind/src/index.native.test.css

--- a/packages/tailwind/src/index.prefixed.test.css
+++ b/packages/tailwind/src/index.prefixed.test.css
@@ -1,0 +1,30720 @@
+.xpto-icon-default {
+    display: inline-block;
+    padding: 0px;
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-default.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-default.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-inherit.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-current.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-transparent.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-black.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-white.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-slate.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-gray.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-zinc.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-neutral.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-stone.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-red.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-orange.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-amber.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-yellow.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-lime.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-green.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-emerald.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-teal.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-cyan.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-sky.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-blue.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-indigo.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-violet.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-purple.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-fuchsia.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-pink.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-rose.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-50.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-100.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-200.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-300.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-400.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-500.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-600.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-700.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-800.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-900.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-950.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-inherit-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-inherit-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-inherit-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-inherit-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-base.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-inherit-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-inherit-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-inherit-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-inherit-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-inherit-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-inherit-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-inherit-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-inherit-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-inherit-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: inherit
+}
+.xpto-icon-inherit-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: inherit
+}
+.xpto-icon-current-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-current-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-current-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-current-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-base.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-current-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-current-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-current-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-current-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-current-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-current-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-current-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-current-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-current-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: currentColor
+}
+.xpto-icon-current-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: currentColor
+}
+.xpto-icon-transparent-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-transparent-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-transparent-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-transparent-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-base.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-transparent-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-transparent-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-transparent-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-transparent-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-transparent-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-transparent-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-transparent-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-transparent-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-transparent-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: transparent
+}
+.xpto-icon-transparent-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: transparent
+}
+.xpto-icon-black-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-black-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-black-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-black-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-black-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-black-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-black-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-black-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-black-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-black-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-black-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-black-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-black-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #000
+}
+.xpto-icon-black-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #000
+}
+.xpto-icon-white-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-white-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-white-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-white-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-white-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-white-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-white-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-white-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-white-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-white-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-white-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-white-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-white-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff
+}
+.xpto-icon-white-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff
+}
+.xpto-icon-slate-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f8fafc
+}
+.xpto-icon-slate-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f8fafc
+}
+.xpto-icon-slate-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f1f5f9
+}
+.xpto-icon-slate-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f1f5f9
+}
+.xpto-icon-slate-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e2e8f0
+}
+.xpto-icon-slate-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e2e8f0
+}
+.xpto-icon-slate-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cbd5e1
+}
+.xpto-icon-slate-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cbd5e1
+}
+.xpto-icon-slate-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #94a3b8
+}
+.xpto-icon-slate-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #94a3b8
+}
+.xpto-icon-slate-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #64748b
+}
+.xpto-icon-slate-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #64748b
+}
+.xpto-icon-slate-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #475569
+}
+.xpto-icon-slate-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #475569
+}
+.xpto-icon-slate-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #334155
+}
+.xpto-icon-slate-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #334155
+}
+.xpto-icon-slate-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e293b
+}
+.xpto-icon-slate-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e293b
+}
+.xpto-icon-slate-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f172a
+}
+.xpto-icon-slate-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f172a
+}
+.xpto-icon-slate-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-slate-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-slate-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-slate-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-slate-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-slate-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-slate-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-slate-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-slate-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-slate-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-slate-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-slate-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-slate-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #020617
+}
+.xpto-icon-slate-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #020617
+}
+.xpto-icon-gray-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9fafb
+}
+.xpto-icon-gray-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9fafb
+}
+.xpto-icon-gray-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3f4f6
+}
+.xpto-icon-gray-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3f4f6
+}
+.xpto-icon-gray-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e7eb
+}
+.xpto-icon-gray-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e7eb
+}
+.xpto-icon-gray-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1d5db
+}
+.xpto-icon-gray-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1d5db
+}
+.xpto-icon-gray-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9ca3af
+}
+.xpto-icon-gray-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9ca3af
+}
+.xpto-icon-gray-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b7280
+}
+.xpto-icon-gray-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b7280
+}
+.xpto-icon-gray-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4b5563
+}
+.xpto-icon-gray-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4b5563
+}
+.xpto-icon-gray-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #374151
+}
+.xpto-icon-gray-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #374151
+}
+.xpto-icon-gray-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1f2937
+}
+.xpto-icon-gray-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1f2937
+}
+.xpto-icon-gray-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #111827
+}
+.xpto-icon-gray-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #111827
+}
+.xpto-icon-gray-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-gray-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-gray-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-gray-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-gray-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-gray-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-gray-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-gray-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-gray-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-gray-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-gray-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-gray-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-gray-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #030712
+}
+.xpto-icon-gray-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #030712
+}
+.xpto-icon-zinc-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-zinc-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-zinc-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f4f4f5
+}
+.xpto-icon-zinc-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f4f4f5
+}
+.xpto-icon-zinc-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e4e4e7
+}
+.xpto-icon-zinc-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e4e4e7
+}
+.xpto-icon-zinc-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d8
+}
+.xpto-icon-zinc-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d8
+}
+.xpto-icon-zinc-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a1a1aa
+}
+.xpto-icon-zinc-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a1a1aa
+}
+.xpto-icon-zinc-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #71717a
+}
+.xpto-icon-zinc-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #71717a
+}
+.xpto-icon-zinc-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #52525b
+}
+.xpto-icon-zinc-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #52525b
+}
+.xpto-icon-zinc-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f3f46
+}
+.xpto-icon-zinc-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f3f46
+}
+.xpto-icon-zinc-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #27272a
+}
+.xpto-icon-zinc-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #27272a
+}
+.xpto-icon-zinc-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #18181b
+}
+.xpto-icon-zinc-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #18181b
+}
+.xpto-icon-zinc-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-zinc-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-zinc-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-zinc-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-zinc-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-zinc-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-zinc-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-zinc-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-zinc-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-zinc-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-zinc-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-zinc-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-zinc-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #09090b
+}
+.xpto-icon-zinc-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #09090b
+}
+.xpto-icon-neutral-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafafa
+}
+.xpto-icon-neutral-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafafa
+}
+.xpto-icon-neutral-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f5
+}
+.xpto-icon-neutral-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f5
+}
+.xpto-icon-neutral-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e5e5e5
+}
+.xpto-icon-neutral-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e5e5e5
+}
+.xpto-icon-neutral-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d4d4d4
+}
+.xpto-icon-neutral-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d4d4d4
+}
+.xpto-icon-neutral-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3a3a3
+}
+.xpto-icon-neutral-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3a3a3
+}
+.xpto-icon-neutral-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #737373
+}
+.xpto-icon-neutral-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #737373
+}
+.xpto-icon-neutral-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #525252
+}
+.xpto-icon-neutral-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #525252
+}
+.xpto-icon-neutral-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #404040
+}
+.xpto-icon-neutral-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #404040
+}
+.xpto-icon-neutral-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #262626
+}
+.xpto-icon-neutral-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #262626
+}
+.xpto-icon-neutral-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #171717
+}
+.xpto-icon-neutral-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #171717
+}
+.xpto-icon-neutral-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-neutral-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-neutral-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-neutral-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-neutral-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-neutral-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-neutral-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-neutral-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-neutral-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-neutral-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-neutral-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-neutral-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-neutral-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0a0a0a
+}
+.xpto-icon-neutral-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0a0a0a
+}
+.xpto-icon-stone-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fafaf9
+}
+.xpto-icon-stone-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fafaf9
+}
+.xpto-icon-stone-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f5f4
+}
+.xpto-icon-stone-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f5f4
+}
+.xpto-icon-stone-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e7e5e4
+}
+.xpto-icon-stone-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e7e5e4
+}
+.xpto-icon-stone-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d6d3d1
+}
+.xpto-icon-stone-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d6d3d1
+}
+.xpto-icon-stone-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a8a29e
+}
+.xpto-icon-stone-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a8a29e
+}
+.xpto-icon-stone-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78716c
+}
+.xpto-icon-stone-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78716c
+}
+.xpto-icon-stone-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #57534e
+}
+.xpto-icon-stone-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #57534e
+}
+.xpto-icon-stone-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #44403c
+}
+.xpto-icon-stone-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #44403c
+}
+.xpto-icon-stone-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #292524
+}
+.xpto-icon-stone-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #292524
+}
+.xpto-icon-stone-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1c1917
+}
+.xpto-icon-stone-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1c1917
+}
+.xpto-icon-stone-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-stone-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-stone-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-stone-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-stone-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-stone-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-stone-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-stone-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-stone-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-stone-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-stone-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-stone-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-stone-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c0a09
+}
+.xpto-icon-stone-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c0a09
+}
+.xpto-icon-red-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef2f2
+}
+.xpto-icon-red-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef2f2
+}
+.xpto-icon-red-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fee2e2
+}
+.xpto-icon-red-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fee2e2
+}
+.xpto-icon-red-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecaca
+}
+.xpto-icon-red-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecaca
+}
+.xpto-icon-red-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fca5a5
+}
+.xpto-icon-red-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fca5a5
+}
+.xpto-icon-red-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f87171
+}
+.xpto-icon-red-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f87171
+}
+.xpto-icon-red-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ef4444
+}
+.xpto-icon-red-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ef4444
+}
+.xpto-icon-red-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dc2626
+}
+.xpto-icon-red-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dc2626
+}
+.xpto-icon-red-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b91c1c
+}
+.xpto-icon-red-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b91c1c
+}
+.xpto-icon-red-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #991b1b
+}
+.xpto-icon-red-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #991b1b
+}
+.xpto-icon-red-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7f1d1d
+}
+.xpto-icon-red-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7f1d1d
+}
+.xpto-icon-red-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-red-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-red-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-red-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-red-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-red-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-red-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-red-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-red-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-red-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-red-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-red-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-red-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #450a0a
+}
+.xpto-icon-red-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #450a0a
+}
+.xpto-icon-orange-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff7ed
+}
+.xpto-icon-orange-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff7ed
+}
+.xpto-icon-orange-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffedd5
+}
+.xpto-icon-orange-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffedd5
+}
+.xpto-icon-orange-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fed7aa
+}
+.xpto-icon-orange-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fed7aa
+}
+.xpto-icon-orange-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdba74
+}
+.xpto-icon-orange-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdba74
+}
+.xpto-icon-orange-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb923c
+}
+.xpto-icon-orange-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb923c
+}
+.xpto-icon-orange-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f97316
+}
+.xpto-icon-orange-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f97316
+}
+.xpto-icon-orange-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ea580c
+}
+.xpto-icon-orange-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ea580c
+}
+.xpto-icon-orange-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c2410c
+}
+.xpto-icon-orange-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c2410c
+}
+.xpto-icon-orange-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9a3412
+}
+.xpto-icon-orange-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9a3412
+}
+.xpto-icon-orange-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c2d12
+}
+.xpto-icon-orange-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c2d12
+}
+.xpto-icon-orange-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-orange-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-orange-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-orange-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-orange-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-orange-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-orange-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-orange-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-orange-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-orange-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-orange-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-orange-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-orange-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #431407
+}
+.xpto-icon-orange-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #431407
+}
+.xpto-icon-amber-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fffbeb
+}
+.xpto-icon-amber-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fffbeb
+}
+.xpto-icon-amber-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef3c7
+}
+.xpto-icon-amber-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef3c7
+}
+.xpto-icon-amber-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde68a
+}
+.xpto-icon-amber-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde68a
+}
+.xpto-icon-amber-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fcd34d
+}
+.xpto-icon-amber-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fcd34d
+}
+.xpto-icon-amber-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbbf24
+}
+.xpto-icon-amber-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbbf24
+}
+.xpto-icon-amber-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f59e0b
+}
+.xpto-icon-amber-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f59e0b
+}
+.xpto-icon-amber-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d97706
+}
+.xpto-icon-amber-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d97706
+}
+.xpto-icon-amber-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #b45309
+}
+.xpto-icon-amber-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #b45309
+}
+.xpto-icon-amber-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #92400e
+}
+.xpto-icon-amber-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #92400e
+}
+.xpto-icon-amber-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #78350f
+}
+.xpto-icon-amber-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #78350f
+}
+.xpto-icon-amber-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-amber-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-amber-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-amber-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-amber-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-amber-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-amber-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-amber-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-amber-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-amber-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-amber-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-amber-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-amber-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #451a03
+}
+.xpto-icon-amber-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #451a03
+}
+.xpto-icon-yellow-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fefce8
+}
+.xpto-icon-yellow-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fefce8
+}
+.xpto-icon-yellow-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef9c3
+}
+.xpto-icon-yellow-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef9c3
+}
+.xpto-icon-yellow-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fef08a
+}
+.xpto-icon-yellow-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fef08a
+}
+.xpto-icon-yellow-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fde047
+}
+.xpto-icon-yellow-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fde047
+}
+.xpto-icon-yellow-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #facc15
+}
+.xpto-icon-yellow-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #facc15
+}
+.xpto-icon-yellow-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eab308
+}
+.xpto-icon-yellow-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eab308
+}
+.xpto-icon-yellow-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ca8a04
+}
+.xpto-icon-yellow-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ca8a04
+}
+.xpto-icon-yellow-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a16207
+}
+.xpto-icon-yellow-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a16207
+}
+.xpto-icon-yellow-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #854d0e
+}
+.xpto-icon-yellow-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #854d0e
+}
+.xpto-icon-yellow-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #713f12
+}
+.xpto-icon-yellow-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #713f12
+}
+.xpto-icon-yellow-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-yellow-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-yellow-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-yellow-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-yellow-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-yellow-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-yellow-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-yellow-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-yellow-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-yellow-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-yellow-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-yellow-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-yellow-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #422006
+}
+.xpto-icon-yellow-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #422006
+}
+.xpto-icon-lime-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f7fee7
+}
+.xpto-icon-lime-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f7fee7
+}
+.xpto-icon-lime-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfccb
+}
+.xpto-icon-lime-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfccb
+}
+.xpto-icon-lime-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d9f99d
+}
+.xpto-icon-lime-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d9f99d
+}
+.xpto-icon-lime-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bef264
+}
+.xpto-icon-lime-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bef264
+}
+.xpto-icon-lime-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a3e635
+}
+.xpto-icon-lime-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a3e635
+}
+.xpto-icon-lime-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #84cc16
+}
+.xpto-icon-lime-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #84cc16
+}
+.xpto-icon-lime-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #65a30d
+}
+.xpto-icon-lime-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #65a30d
+}
+.xpto-icon-lime-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4d7c0f
+}
+.xpto-icon-lime-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4d7c0f
+}
+.xpto-icon-lime-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3f6212
+}
+.xpto-icon-lime-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3f6212
+}
+.xpto-icon-lime-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #365314
+}
+.xpto-icon-lime-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #365314
+}
+.xpto-icon-lime-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-lime-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-lime-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-lime-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-lime-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-lime-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-lime-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-lime-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-lime-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-lime-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-lime-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-lime-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-lime-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1a2e05
+}
+.xpto-icon-lime-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1a2e05
+}
+.xpto-icon-green-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdf4
+}
+.xpto-icon-green-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdf4
+}
+.xpto-icon-green-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dcfce7
+}
+.xpto-icon-green-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dcfce7
+}
+.xpto-icon-green-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bbf7d0
+}
+.xpto-icon-green-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bbf7d0
+}
+.xpto-icon-green-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86efac
+}
+.xpto-icon-green-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86efac
+}
+.xpto-icon-green-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4ade80
+}
+.xpto-icon-green-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4ade80
+}
+.xpto-icon-green-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22c55e
+}
+.xpto-icon-green-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22c55e
+}
+.xpto-icon-green-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #16a34a
+}
+.xpto-icon-green-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #16a34a
+}
+.xpto-icon-green-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #15803d
+}
+.xpto-icon-green-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #15803d
+}
+.xpto-icon-green-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #166534
+}
+.xpto-icon-green-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #166534
+}
+.xpto-icon-green-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14532d
+}
+.xpto-icon-green-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14532d
+}
+.xpto-icon-green-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-green-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-green-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-green-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-green-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-green-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-green-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-green-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-green-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-green-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-green-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-green-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-green-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #052e16
+}
+.xpto-icon-green-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #052e16
+}
+.xpto-icon-emerald-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfdf5
+}
+.xpto-icon-emerald-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfdf5
+}
+.xpto-icon-emerald-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d1fae5
+}
+.xpto-icon-emerald-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d1fae5
+}
+.xpto-icon-emerald-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a7f3d0
+}
+.xpto-icon-emerald-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a7f3d0
+}
+.xpto-icon-emerald-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6ee7b7
+}
+.xpto-icon-emerald-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6ee7b7
+}
+.xpto-icon-emerald-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #34d399
+}
+.xpto-icon-emerald-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #34d399
+}
+.xpto-icon-emerald-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #10b981
+}
+.xpto-icon-emerald-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #10b981
+}
+.xpto-icon-emerald-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #059669
+}
+.xpto-icon-emerald-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #059669
+}
+.xpto-icon-emerald-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #047857
+}
+.xpto-icon-emerald-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #047857
+}
+.xpto-icon-emerald-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #065f46
+}
+.xpto-icon-emerald-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #065f46
+}
+.xpto-icon-emerald-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #064e3b
+}
+.xpto-icon-emerald-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #064e3b
+}
+.xpto-icon-emerald-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-emerald-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-emerald-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-emerald-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-emerald-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-emerald-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-emerald-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-emerald-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-emerald-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-emerald-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-emerald-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-emerald-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-emerald-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #022c22
+}
+.xpto-icon-emerald-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #022c22
+}
+.xpto-icon-teal-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0fdfa
+}
+.xpto-icon-teal-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0fdfa
+}
+.xpto-icon-teal-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ccfbf1
+}
+.xpto-icon-teal-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ccfbf1
+}
+.xpto-icon-teal-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #99f6e4
+}
+.xpto-icon-teal-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #99f6e4
+}
+.xpto-icon-teal-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5eead4
+}
+.xpto-icon-teal-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5eead4
+}
+.xpto-icon-teal-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2dd4bf
+}
+.xpto-icon-teal-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2dd4bf
+}
+.xpto-icon-teal-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #14b8a6
+}
+.xpto-icon-teal-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #14b8a6
+}
+.xpto-icon-teal-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0d9488
+}
+.xpto-icon-teal-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0d9488
+}
+.xpto-icon-teal-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0f766e
+}
+.xpto-icon-teal-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0f766e
+}
+.xpto-icon-teal-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #115e59
+}
+.xpto-icon-teal-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #115e59
+}
+.xpto-icon-teal-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #134e4a
+}
+.xpto-icon-teal-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #134e4a
+}
+.xpto-icon-teal-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-teal-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-teal-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-teal-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-teal-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-teal-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-teal-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-teal-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-teal-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-teal-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-teal-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-teal-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-teal-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #042f2e
+}
+.xpto-icon-teal-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #042f2e
+}
+.xpto-icon-cyan-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ecfeff
+}
+.xpto-icon-cyan-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ecfeff
+}
+.xpto-icon-cyan-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #cffafe
+}
+.xpto-icon-cyan-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #cffafe
+}
+.xpto-icon-cyan-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5f3fc
+}
+.xpto-icon-cyan-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5f3fc
+}
+.xpto-icon-cyan-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #67e8f9
+}
+.xpto-icon-cyan-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #67e8f9
+}
+.xpto-icon-cyan-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #22d3ee
+}
+.xpto-icon-cyan-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #22d3ee
+}
+.xpto-icon-cyan-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #06b6d4
+}
+.xpto-icon-cyan-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #06b6d4
+}
+.xpto-icon-cyan-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0891b2
+}
+.xpto-icon-cyan-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0891b2
+}
+.xpto-icon-cyan-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0e7490
+}
+.xpto-icon-cyan-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0e7490
+}
+.xpto-icon-cyan-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #155e75
+}
+.xpto-icon-cyan-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #155e75
+}
+.xpto-icon-cyan-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #164e63
+}
+.xpto-icon-cyan-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #164e63
+}
+.xpto-icon-cyan-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-cyan-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-cyan-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-cyan-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-cyan-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-cyan-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-cyan-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-cyan-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-cyan-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-cyan-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-cyan-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-cyan-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-cyan-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #083344
+}
+.xpto-icon-cyan-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #083344
+}
+.xpto-icon-sky-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0f9ff
+}
+.xpto-icon-sky-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0f9ff
+}
+.xpto-icon-sky-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0f2fe
+}
+.xpto-icon-sky-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0f2fe
+}
+.xpto-icon-sky-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bae6fd
+}
+.xpto-icon-sky-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bae6fd
+}
+.xpto-icon-sky-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7dd3fc
+}
+.xpto-icon-sky-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7dd3fc
+}
+.xpto-icon-sky-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #38bdf8
+}
+.xpto-icon-sky-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #38bdf8
+}
+.xpto-icon-sky-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0ea5e9
+}
+.xpto-icon-sky-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0ea5e9
+}
+.xpto-icon-sky-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0284c7
+}
+.xpto-icon-sky-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0284c7
+}
+.xpto-icon-sky-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0369a1
+}
+.xpto-icon-sky-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0369a1
+}
+.xpto-icon-sky-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #075985
+}
+.xpto-icon-sky-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #075985
+}
+.xpto-icon-sky-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #0c4a6e
+}
+.xpto-icon-sky-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #0c4a6e
+}
+.xpto-icon-sky-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-sky-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-sky-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-sky-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-sky-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-sky-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-sky-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-sky-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-sky-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-sky-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-sky-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-sky-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-sky-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #082f49
+}
+.xpto-icon-sky-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #082f49
+}
+.xpto-icon-blue-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eff6ff
+}
+.xpto-icon-blue-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eff6ff
+}
+.xpto-icon-blue-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #dbeafe
+}
+.xpto-icon-blue-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #dbeafe
+}
+.xpto-icon-blue-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #bfdbfe
+}
+.xpto-icon-blue-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #bfdbfe
+}
+.xpto-icon-blue-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #93c5fd
+}
+.xpto-icon-blue-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #93c5fd
+}
+.xpto-icon-blue-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #60a5fa
+}
+.xpto-icon-blue-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #60a5fa
+}
+.xpto-icon-blue-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b82f6
+}
+.xpto-icon-blue-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b82f6
+}
+.xpto-icon-blue-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2563eb
+}
+.xpto-icon-blue-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2563eb
+}
+.xpto-icon-blue-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1d4ed8
+}
+.xpto-icon-blue-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1d4ed8
+}
+.xpto-icon-blue-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e40af
+}
+.xpto-icon-blue-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e40af
+}
+.xpto-icon-blue-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e3a8a
+}
+.xpto-icon-blue-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e3a8a
+}
+.xpto-icon-blue-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-blue-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-blue-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-blue-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-blue-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-blue-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-blue-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-blue-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-blue-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-blue-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-blue-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-blue-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-blue-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #172554
+}
+.xpto-icon-blue-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #172554
+}
+.xpto-icon-indigo-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #eef2ff
+}
+.xpto-icon-indigo-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #eef2ff
+}
+.xpto-icon-indigo-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e0e7ff
+}
+.xpto-icon-indigo-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e0e7ff
+}
+.xpto-icon-indigo-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c7d2fe
+}
+.xpto-icon-indigo-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c7d2fe
+}
+.xpto-icon-indigo-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a5b4fc
+}
+.xpto-icon-indigo-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a5b4fc
+}
+.xpto-icon-indigo-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #818cf8
+}
+.xpto-icon-indigo-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #818cf8
+}
+.xpto-icon-indigo-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6366f1
+}
+.xpto-icon-indigo-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6366f1
+}
+.xpto-icon-indigo-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4f46e5
+}
+.xpto-icon-indigo-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4f46e5
+}
+.xpto-icon-indigo-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4338ca
+}
+.xpto-icon-indigo-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4338ca
+}
+.xpto-icon-indigo-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3730a3
+}
+.xpto-icon-indigo-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3730a3
+}
+.xpto-icon-indigo-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #312e81
+}
+.xpto-icon-indigo-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #312e81
+}
+.xpto-icon-indigo-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-indigo-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-indigo-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-indigo-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-indigo-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-indigo-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-indigo-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-indigo-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-indigo-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-indigo-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-indigo-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-indigo-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-indigo-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #1e1b4b
+}
+.xpto-icon-indigo-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #1e1b4b
+}
+.xpto-icon-violet-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5f3ff
+}
+.xpto-icon-violet-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5f3ff
+}
+.xpto-icon-violet-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ede9fe
+}
+.xpto-icon-violet-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ede9fe
+}
+.xpto-icon-violet-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ddd6fe
+}
+.xpto-icon-violet-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ddd6fe
+}
+.xpto-icon-violet-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c4b5fd
+}
+.xpto-icon-violet-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c4b5fd
+}
+.xpto-icon-violet-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a78bfa
+}
+.xpto-icon-violet-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a78bfa
+}
+.xpto-icon-violet-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #8b5cf6
+}
+.xpto-icon-violet-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #8b5cf6
+}
+.xpto-icon-violet-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7c3aed
+}
+.xpto-icon-violet-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7c3aed
+}
+.xpto-icon-violet-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6d28d9
+}
+.xpto-icon-violet-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6d28d9
+}
+.xpto-icon-violet-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #5b21b6
+}
+.xpto-icon-violet-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #5b21b6
+}
+.xpto-icon-violet-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c1d95
+}
+.xpto-icon-violet-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c1d95
+}
+.xpto-icon-violet-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-violet-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-violet-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-violet-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-violet-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-violet-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-violet-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-violet-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-violet-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-violet-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-violet-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-violet-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-violet-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #2e1065
+}
+.xpto-icon-violet-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #2e1065
+}
+.xpto-icon-purple-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #faf5ff
+}
+.xpto-icon-purple-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #faf5ff
+}
+.xpto-icon-purple-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f3e8ff
+}
+.xpto-icon-purple-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f3e8ff
+}
+.xpto-icon-purple-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e9d5ff
+}
+.xpto-icon-purple-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e9d5ff
+}
+.xpto-icon-purple-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d8b4fe
+}
+.xpto-icon-purple-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d8b4fe
+}
+.xpto-icon-purple-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c084fc
+}
+.xpto-icon-purple-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c084fc
+}
+.xpto-icon-purple-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a855f7
+}
+.xpto-icon-purple-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a855f7
+}
+.xpto-icon-purple-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9333ea
+}
+.xpto-icon-purple-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9333ea
+}
+.xpto-icon-purple-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #7e22ce
+}
+.xpto-icon-purple-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #7e22ce
+}
+.xpto-icon-purple-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #6b21a8
+}
+.xpto-icon-purple-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #6b21a8
+}
+.xpto-icon-purple-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #581c87
+}
+.xpto-icon-purple-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #581c87
+}
+.xpto-icon-purple-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-purple-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-purple-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-purple-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-purple-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-purple-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-purple-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-purple-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-purple-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-purple-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-purple-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-purple-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-purple-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #3b0764
+}
+.xpto-icon-purple-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #3b0764
+}
+.xpto-icon-fuchsia-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf4ff
+}
+.xpto-icon-fuchsia-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf4ff
+}
+.xpto-icon-fuchsia-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fae8ff
+}
+.xpto-icon-fuchsia-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fae8ff
+}
+.xpto-icon-fuchsia-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f5d0fe
+}
+.xpto-icon-fuchsia-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f5d0fe
+}
+.xpto-icon-fuchsia-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f0abfc
+}
+.xpto-icon-fuchsia-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f0abfc
+}
+.xpto-icon-fuchsia-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e879f9
+}
+.xpto-icon-fuchsia-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e879f9
+}
+.xpto-icon-fuchsia-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #d946ef
+}
+.xpto-icon-fuchsia-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #d946ef
+}
+.xpto-icon-fuchsia-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #c026d3
+}
+.xpto-icon-fuchsia-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #c026d3
+}
+.xpto-icon-fuchsia-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #a21caf
+}
+.xpto-icon-fuchsia-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #a21caf
+}
+.xpto-icon-fuchsia-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #86198f
+}
+.xpto-icon-fuchsia-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #86198f
+}
+.xpto-icon-fuchsia-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #701a75
+}
+.xpto-icon-fuchsia-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #701a75
+}
+.xpto-icon-fuchsia-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-fuchsia-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-fuchsia-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-fuchsia-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-fuchsia-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-fuchsia-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-fuchsia-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-fuchsia-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-fuchsia-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-fuchsia-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-fuchsia-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-fuchsia-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-fuchsia-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4a044e
+}
+.xpto-icon-fuchsia-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4a044e
+}
+.xpto-icon-pink-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fdf2f8
+}
+.xpto-icon-pink-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fdf2f8
+}
+.xpto-icon-pink-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fce7f3
+}
+.xpto-icon-pink-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fce7f3
+}
+.xpto-icon-pink-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fbcfe8
+}
+.xpto-icon-pink-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fbcfe8
+}
+.xpto-icon-pink-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f9a8d4
+}
+.xpto-icon-pink-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f9a8d4
+}
+.xpto-icon-pink-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f472b6
+}
+.xpto-icon-pink-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f472b6
+}
+.xpto-icon-pink-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ec4899
+}
+.xpto-icon-pink-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ec4899
+}
+.xpto-icon-pink-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #db2777
+}
+.xpto-icon-pink-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #db2777
+}
+.xpto-icon-pink-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be185d
+}
+.xpto-icon-pink-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be185d
+}
+.xpto-icon-pink-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9d174d
+}
+.xpto-icon-pink-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9d174d
+}
+.xpto-icon-pink-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #831843
+}
+.xpto-icon-pink-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #831843
+}
+.xpto-icon-pink-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-pink-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-pink-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-pink-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-pink-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-pink-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-pink-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-pink-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-pink-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-pink-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-pink-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-pink-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-pink-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #500724
+}
+.xpto-icon-pink-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #500724
+}
+.xpto-icon-rose-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-50-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-50-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-50-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-50-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-50-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-50-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-50-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-50-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-50-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-50-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-50-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-50-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-50-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fff1f2
+}
+.xpto-icon-rose-50-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fff1f2
+}
+.xpto-icon-rose-100-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-100-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-100-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-100-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-100-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-100-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-100-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-100-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-100-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-100-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-100-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-100-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-100-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #ffe4e6
+}
+.xpto-icon-rose-100-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #ffe4e6
+}
+.xpto-icon-rose-200-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-200-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-200-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-200-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-200-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-200-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-200-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-200-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-200-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-200-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-200-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-200-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-200-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fecdd3
+}
+.xpto-icon-rose-200-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fecdd3
+}
+.xpto-icon-rose-300-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-300-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-300-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-300-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-300-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-300-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-300-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-300-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-300-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-300-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-300-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-300-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-300-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fda4af
+}
+.xpto-icon-rose-300-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fda4af
+}
+.xpto-icon-rose-400-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-400-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-400-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-400-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-400-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-400-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-400-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-400-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-400-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-400-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-400-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-400-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-400-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #fb7185
+}
+.xpto-icon-rose-400-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #fb7185
+}
+.xpto-icon-rose-500-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-500-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-500-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-500-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-500-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-500-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-500-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-500-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-500-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-500-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-500-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-500-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-500-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #f43f5e
+}
+.xpto-icon-rose-500-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #f43f5e
+}
+.xpto-icon-rose-600-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-600-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-600-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-600-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-600-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-600-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-600-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-600-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-600-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-600-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-600-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-600-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-600-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #e11d48
+}
+.xpto-icon-rose-600-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #e11d48
+}
+.xpto-icon-rose-700-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-700-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-700-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-700-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-700-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-700-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-700-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-700-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-700-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-700-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-700-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-700-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-700-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #be123c
+}
+.xpto-icon-rose-700-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #be123c
+}
+.xpto-icon-rose-800-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-800-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-800-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-800-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-800-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-800-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-800-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-800-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-800-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-800-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-800-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-800-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-800-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #9f1239
+}
+.xpto-icon-rose-800-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #9f1239
+}
+.xpto-icon-rose-900-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-900-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-900-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-900-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-900-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-900-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-900-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-900-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-900-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-900-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-900-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-900-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-900-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #881337
+}
+.xpto-icon-rose-900-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #881337
+}
+.xpto-icon-rose-950-xs.xpto-icon-ri {
+    height: 0.5rem
+}
+.xpto-icon-rose-950-xs.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-xs.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-sm.xpto-icon-ri {
+    height: 1rem
+}
+.xpto-icon-rose-950-sm.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-sm.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-base.xpto-icon-ri {
+    height: 1.25rem;
+    width: 1.25rem
+}
+.xpto-icon-rose-950-base.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-base.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-lg.xpto-icon-ri {
+    height: 1.5rem;
+    width: 1.5rem
+}
+.xpto-icon-rose-950-lg.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-lg.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-xl.xpto-icon-ri {
+    height: 1.75rem;
+    width: 1.75rem
+}
+.xpto-icon-rose-950-xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-2xl.xpto-icon-ri {
+    height: 2rem;
+    width: 2rem
+}
+.xpto-icon-rose-950-2xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-2xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-3xl.xpto-icon-ri {
+    height: 2.25rem;
+    width: 2.25rem
+}
+.xpto-icon-rose-950-3xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-3xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-4xl.xpto-icon-ri {
+    height: 2.5rem;
+    width: 2.5rem
+}
+.xpto-icon-rose-950-4xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-4xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-5xl.xpto-icon-ri {
+    height: 2.75rem;
+    width: 2.75rem
+}
+.xpto-icon-rose-950-5xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-5xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-6xl.xpto-icon-ri {
+    height: 3rem;
+    width: 3rem
+}
+.xpto-icon-rose-950-6xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-6xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}
+.xpto-icon-rose-950-7xl.xpto-icon-ri {
+    height: 3.5rem;
+    width: 3.5rem
+}
+.xpto-icon-rose-950-7xl.xpto-icon-ri.xpto-icon-outlined {
+    stroke: #4c0519
+}
+.xpto-icon-rose-950-7xl.xpto-icon-ri.xpto-icon-filled {
+    fill: #4c0519
+}

--- a/packages/tailwind/src/index.test.ts
+++ b/packages/tailwind/src/index.test.ts
@@ -13,6 +13,11 @@ import { iconPlugin, nativeIconPlugin } from "./index";
 const sourceCssFile = path.join(path.resolve(process.cwd()), "src/index.test.css");
 const sourceNativeCssFile = path.join(path.resolve(process.cwd()), "src/index.native.test.css");
 
+const prefixedSourceCssFile = path.join(
+  path.resolve(process.cwd()),
+  "src/index.prefixed.test.css"
+);
+
 describe("plugin", () => {
   describe("web", () => {
     test("Should generate the css without creating a giant bundler", async () => {
@@ -83,6 +88,30 @@ describe("plugin", () => {
           from: undefined
         }
       );
+      expect(css).toBe(expectation.toString());
+    });
+  });
+
+  describe("Tailwind with prefix", () => {
+    test("Should generate the css with prefix", async () => {
+      const expectation = fs.readFileSync(prefixedSourceCssFile);
+      const config = resolveConfig({
+        ...tailwindConfig,
+        plugins: [iconPlugin],
+        prefix: "xpto-",
+        safelist: [
+          {
+            pattern: /icon-*/
+          }
+        ]
+      });
+      const { css } = await postcss([tailwind(config as unknown as Config)]).process(
+        "@tailwind components;",
+        {
+          from: undefined
+        }
+      );
+
       expect(css).toBe(expectation.toString());
     });
   });

--- a/packages/tailwind/src/index.ts
+++ b/packages/tailwind/src/index.ts
@@ -4,15 +4,47 @@ import { CSSRuleObject, PluginAPI } from "tailwindcss/types/config";
 import DefaultTheme from "./theme";
 import { stylesGenerator } from "./utils/styles-generator";
 import { configHandler } from "./utils/config-handler";
+import { ThemeOptions } from "./types";
+
+const addPrefixToTheme = (theme: ThemeOptions, prefix: string): ThemeOptions => {
+  const baseStyleClasses = theme.baseStyle?.split(" ") ?? [];
+
+  const baseStyle = baseStyleClasses.reduce((acc: string, value) => {
+    return (acc += `${prefix}${value} `);
+  }, "");
+
+  const sizes = Object.entries(theme.sizes).reduce(
+    (acc: { [key: string]: string }, [key, value]) => {
+      const sizeClasses = value.split(" ") ?? [];
+
+      const newClassesArray = sizeClasses.reduce((acc: string[], value) => {
+        return [...acc, `${prefix}${value}`];
+      }, []);
+
+      acc[key] = newClassesArray.join(" ");
+      return acc;
+    },
+    {}
+  );
+
+  return {
+    ...theme,
+    baseStyle,
+    sizes
+  };
+};
 
 const pluginFactory = (isNative: boolean = false) => {
   return plugin(
     ({ addComponents, config }: PluginAPI) => {
-      const prefix = config("prefix") ?? "";
-      const classPrefix = `${prefix}icon`;
-      const handler = configHandler(config);
-      const theme = handler("icon", DefaultTheme);
-      const generator = stylesGenerator(classPrefix, isNative);
+      const prefix = (config("prefix") as string) ?? "";
+      const themeModified = addPrefixToTheme(DefaultTheme, prefix);
+
+      const handler = configHandler(config, prefix);
+      const theme = handler("icon", themeModified);
+
+      const generator = stylesGenerator("icon", isNative);
+
       const styles = generator
         .add(theme.defaults())
         .add(theme.sizes())

--- a/packages/tailwind/src/index.ts
+++ b/packages/tailwind/src/index.ts
@@ -1,47 +1,17 @@
 import plugin from "tailwindcss/plugin";
 import { CSSRuleObject, PluginAPI } from "tailwindcss/types/config";
 
-import DefaultTheme from "./theme";
+import getDefaultTheme from "./theme";
 import { stylesGenerator } from "./utils/styles-generator";
 import { configHandler } from "./utils/config-handler";
-import { ThemeOptions } from "./types";
-
-const addPrefixToTheme = (theme: ThemeOptions, prefix: string): ThemeOptions => {
-  const baseStyleClasses = theme.baseStyle?.split(" ") ?? [];
-
-  const baseStyle = baseStyleClasses.reduce((acc: string, value) => {
-    return (acc += `${prefix}${value} `);
-  }, "");
-
-  const sizes = Object.entries(theme.sizes).reduce(
-    (acc: { [key: string]: string }, [key, value]) => {
-      const sizeClasses = value.split(" ") ?? [];
-
-      const newClassesArray = sizeClasses.reduce((acc: string[], value) => {
-        return [...acc, `${prefix}${value}`];
-      }, []);
-
-      acc[key] = newClassesArray.join(" ");
-      return acc;
-    },
-    {}
-  );
-
-  return {
-    ...theme,
-    baseStyle,
-    sizes
-  };
-};
 
 const pluginFactory = (isNative: boolean = false) => {
   return plugin(
     ({ addComponents, config }: PluginAPI) => {
       const prefix = (config("prefix") as string) ?? "";
-      const themeModified = addPrefixToTheme(DefaultTheme, prefix);
-
       const handler = configHandler(config, prefix);
-      const theme = handler("icon", themeModified);
+
+      const theme = handler("icon", getDefaultTheme(prefix));
 
       const generator = stylesGenerator("icon", isNative);
 

--- a/packages/tailwind/src/theme.ts
+++ b/packages/tailwind/src/theme.ts
@@ -1,25 +1,25 @@
 import { ThemeOptions } from "@/types";
 
-const theme: ThemeOptions = {
-  default: "sky-500-base",
-  baseStyle: "p-0 inline-block",
+const getDefaultTheme = (prefix: string = ""): ThemeOptions => ({
+  default: `${prefix}sky-500-base`,
+  baseStyle: `${prefix}p-0 ${prefix}inline-block`,
   variants: {
     filled: "",
     outlined: ""
   },
   sizes: {
-    xs: "h-2",
-    sm: "h-4",
-    base: "h-5 w-5",
-    lg: "h-6 w-6",
-    xl: "h-7 w-7",
-    "2xl": "h-8 w-8",
-    "3xl": "h-9 w-9",
-    "4xl": "h-10 w-10",
-    "5xl": "h-11 w-11",
-    "6xl": "h-12 w-12",
-    "7xl": "h-14 w-14"
+    xs: `${prefix}h-2`,
+    sm: `${prefix}h-4`,
+    base: `${prefix}h-5 ${prefix}w-5`,
+    lg: `${prefix}h-6 ${prefix}w-6`,
+    xl: `${prefix}h-7 ${prefix}w-7`,
+    "2xl": `${prefix}h-8 ${prefix}w-8`,
+    "3xl": `${prefix}h-9 ${prefix}w-9`,
+    "4xl": `${prefix}h-10 ${prefix}w-10`,
+    "5xl": `${prefix}h-11 ${prefix}w-11`,
+    "6xl": `${prefix}h-12 ${prefix}w-12`,
+    "7xl": `${prefix}h-14 ${prefix}w-14`
   }
-};
+});
 
-export default theme;
+export default getDefaultTheme;

--- a/packages/tailwind/src/utils/config-handler.ts
+++ b/packages/tailwind/src/utils/config-handler.ts
@@ -49,29 +49,30 @@ const toShortCutStyles = (theme: ThemeOptions, name: string, color: string, pref
 const generateConfig = <T extends ThemeOptions>(
   theme: T,
   parsedColors: ParsedColors,
-  prefix?: string
+  prefix: string = ""
 ) => {
-  const prefixToAdd = prefix ? prefix : "";
-
   const getDefaults = (): Defaults => {
     const pieces = theme.default!.split("-");
     const defaultSize = pieces.pop()!;
-    return { defaultColor: pieces.join("-"), defaultSize };
+
+    const defaultColor = pieces.join("-").replace(prefix, "");
+
+    return { defaultColor, defaultSize };
   };
 
   const { defaultColor, defaultSize } = getDefaults();
 
   const colors = () =>
     ([] as StyleHandler[]).concat(
-      ...AVAILABLE_VARIANTS.map((variant) => toColorsStyles(parsedColors, variant, prefixToAdd))
+      ...AVAILABLE_VARIANTS.map((variant) => toColorsStyles(parsedColors, variant, prefix))
     );
 
   const sizes = () =>
     ([] as StyleHandler[]).concat(
       ([] as StyleHandler[]).concat(
         ...Object.keys(theme.sizes).map((size) => ({
-          name: () => `${size}`,
-          styles: () => `${sanitize(theme.sizes[size])}`
+          name: () => size,
+          styles: () => sanitize(theme.sizes[size])
         }))
       )
     );
@@ -90,7 +91,7 @@ const generateConfig = <T extends ThemeOptions>(
       name: () => `${DEFAULT_CLASS_NAME}${CLASS_NAME_SEPARATOR}${variant}`,
       styles: () =>
         sanitize(
-          `${theme.variants?.[variant] ?? ""} ${prefixToAdd}${VARIANT_CLASSES[variant]}-${parsedColors[defaultColor]}`
+          `${theme.variants?.[variant] ?? ""} ${prefix}${VARIANT_CLASSES[variant]}-${parsedColors[defaultColor]}`
         )
     }))
   ];
@@ -98,7 +99,7 @@ const generateConfig = <T extends ThemeOptions>(
   const shortcuts = () =>
     ([] as StyleHandler[]).concat(
       ...Object.entries(parsedColors).map(([name, color]) =>
-        toShortCutStyles(theme, name, color, prefixToAdd)
+        toShortCutStyles(theme, name, color, prefix)
       )
     );
 


### PR DESCRIPTION
The idea here is to add the prefix to the classes before sending them to the style generator.

This should fix #145 