### PR TITLE
fix(cicd): use npm ci so TW v4 oxide native binary resolves on Linux

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -72,10 +72,17 @@ jobs:
 
       - name: Install packages
         if: steps.npm-cache.outputs.cache-hit != 'true'
+        # `npm ci` (vs `npm install`) wipes node_modules and reinstalls
+        # strictly from the lockfile. Required for Tailwind v4 because
+        # `@tailwindcss/oxide` ships per-platform native binaries via
+        # optionalDependencies; on partial cache restores from
+        # `restore-keys`, plain `npm install` doesn't add the missing
+        # platform variant (npm/cli#4828) and the integration tests
+        # in @rocketicons/tailwind fail with "Cannot find native binding".
         run: |
           npm config set @rocketclimb:registry https://npm.pkg.github.com
           npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
-          SKIP_BUILD_ALL=true npm install
+          SKIP_BUILD_ALL=true npm ci
 
       - name: Icons Fetch
         if: steps.icons-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

Unblocks the v0.5.0 release pipeline. The `prepare-release` run for #151 failed at `Run tests` with:

> @rocketicons/tailwind: Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828)

## Root cause

`@rocketicons/tailwind`'s integration test loads `@tailwindcss/postcss`, which dynamically loads `@tailwindcss/oxide`, which in turn loads a **per-platform native binary** (`@tailwindcss/oxide-linux-x64-gnu` on the runner) declared as `optionalDependencies`.

Two factors compound:
1. `actions/cache` for `node_modules` uses `restore-keys: Linux-node-` — so even when the exact dependency-hash key misses, it restores an older Linux cache (from before TW v4 was added) that has no oxide-linux binary.
2. The workflow then runs `npm install` (not `npm ci`). With a partial-but-non-empty `node_modules` already in place, `npm install` does NOT detect that the Linux platform variant of an optional dep is missing — that's [npm/cli#4828](https://github.com/npm/cli/issues/4828).

Result: tests fail at module-load with `Cannot find native binding`.

## Fix

Replace `npm install` → `npm ci` in `prepare-release.yml`. `npm ci`:
- always wipes `node_modules` first (so partial restored caches don't poison the install)
- installs strictly from `package-lock.json` (which already records all platform variants — verified)
- correctly fetches the per-platform optional binaries for the runner OS

Verified locally with `npm ci --dry-run` — lockfile is in sync, no errors.

## Why minimal

Only changes one line + comment. Same `node_modules` cache layer, same `actions/cache@v4` setup, same dependency-hash key. No workflow restructuring.

## Test plan

- [ ] Once merged, the develop → main PR (#151) auto-resyncs and `prepare-release` re-runs against develop
- [ ] All test suites pass on Linux runner (utils 22, tailwind 57, others)
- [ ] Releaser proceeds, generates `release-notes.md`, and uploads tag artifact