### PR TITLE
fix(cicd): sync .versions.json + harden release pipeline against silent failures

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -99,10 +99,52 @@ jobs:
           git config user.name ${{ env.AUTOMATION_USER_NAME }}
           git config user.email ${{ env.AUTOMATION_USER_EMAIL }}
 
+      - name: Validate .versions.json is in sync with workspaces
+        # The releaser reads `.versions.json` to compute version bumps; if a
+        # workspace exists in package.json but is missing from
+        # .versions.json, `bumpVersion(undefined, ...)` crashes deep inside
+        # the releaser with a confusing TypeError. Fail fast here with a
+        # clear message so future package additions don't silently break
+        # the release pipeline.
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e '
+            const pkg = require("./package.json");
+            const versions = require("./.versions.json");
+            const workspaceNames = pkg.workspaces.map(ws => ws.split("/").pop());
+            const missing = workspaceNames.filter(name => !(name in versions));
+            if (missing.length) {
+              console.error("::error::.versions.json is missing entries for: " + missing.join(", "));
+              console.error("Add each missing workspace to .versions.json with its current package.json version. See packages/<name>/package.json.");
+              process.exit(1);
+            }
+            console.log(".versions.json covers all " + workspaceNames.length + " workspaces.");
+          '
+
       - name: Prepare tag or release
         id: prepare-release
+        # The releaser script (`npm run release` -> rocketclimb-sh releaser)
+        # prints the tag name on stdout. Previously this step used
+        #   echo "TAG_NAME=$(npm run release | grep v)" >> $GITHUB_OUTPUT
+        # which masked failures: if the releaser crashed (e.g. a package
+        # missing from .versions.json caused a TypeError), the inner pipe
+        # failed but the outer echo still succeeded — the step exited 0
+        # with an empty TAG_NAME and the rest of the workflow silently
+        # produced broken artifacts. Now we use pipefail, write the
+        # releaser output to a file, extract the tag with a strict regex,
+        # and explicitly fail the step if the tag is missing.
+        shell: bash
         run: |
-          echo "TAG_NAME=$(npm run release | grep v)" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          npm run release 2>&1 | tee release-output.log
+          TAG_NAME=$(grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)*' release-output.log | tail -n 1 || true)
+          if [ -z "${TAG_NAME}" ]; then
+            echo "::error::Releaser produced no tag name. The releaser may have crashed; see the 'Run npm run release' output above and release-output.log."
+            exit 1
+          fi
+          echo "Releaser produced tag: ${TAG_NAME}"
+          echo "TAG_NAME=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Build Ignition statics
         run: npm run generate-statics:all-icons --workspace=packages/ignition
@@ -115,9 +157,22 @@ jobs:
         run: |
           echo "URL_ID=$(echo "${{ github.head_ref }}" | tr -s ' ' | tr '[:upper:]' '[:lower:]' | sed 's,[ /\.],-,g' | sed 's/--/-/g')" >> $GITHUB_OUTPUT
 
-      - name: Get genereated package name
+      - name: Get generated package name
         id: generated-pkg-name
-        run: echo "PKG_FILE=$(ls -1 -t *.tgz | head -1)" >> $GITHUB_OUTPUT
+        # Validate the releaser actually produced a tarball before
+        # downstream upload steps try to consume it; previously an empty
+        # PKG_FILE would silently propagate to actions/upload-artifact
+        # and surface as the cryptic "Input required and not supplied: path".
+        shell: bash
+        run: |
+          set -euo pipefail
+          PKG_FILE=$(ls -1 -t *.tgz 2>/dev/null | head -n 1 || true)
+          if [ -z "${PKG_FILE}" ]; then
+            echo "::error::No rocketicons-*.tgz produced by the releaser. Expected one in the repo root."
+            exit 1
+          fi
+          echo "Generated package: ${PKG_FILE}"
+          echo "PKG_FILE=${PKG_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Generate artifact for tag ${{ steps.prepare-release.outputs.TAG_NAME }}
         run: |

--- a/.versions.json
+++ b/.versions.json
@@ -4,6 +4,9 @@
   "generator": "0.2.4",
   "icons": "0.2.8",
   "ignition": "0.4.4",
-  "tailwind": "0.2.5",
+  "tailwind": "0.2.6",
+  "utils": "0.2.7",
+  "cli": "0.2.5",
+  "native-test": "0.1.0",
   "hash": "6c6f1b11d84399ac88e636b36c1d08c8"
 }


### PR DESCRIPTION
## Summary

Third (and hopefully final) fix to unblock the v0.5.0 release pipeline. After getting past the Node 18→22 issue, the next run still failed — but now in a deeper way that exposed both a stale state file and a long-standing class of silent-failure CI bugs.

## What broke

Tests passed on Node 22 ✓, but the release pipeline failed at the artifact upload step with the cryptic `Input required and not supplied: path`. Tracing back:

```
TypeError: Cannot destructure property 'groups' of 'VERSION_MATCHER.exec(...)' as it is null.
    at bumpVersion (utils.js:46)
    at releaser.js:64
```

`bumpVersion(versions[pkgName], type, true)` was being called with `versions[pkgName] === undefined`. Reason: **`.versions.json` was missing `utils`, `cli`, and `native-test`** — workspaces added since the last release that nobody synced into the state file.

The crash happened *before* the `-release` marker / icons-tarball-pack logic. So the releaser exited mid-flight, no `.tgz` was produced, no tag name was emitted, and the workflow merrily marched into upload steps with empty inputs.

## Why we didn't notice the crash

This step:

```yaml
- name: Prepare tag or release
  run: |
    echo "TAG_NAME=$(npm run release | grep v)" >> $GITHUB_OUTPUT
```

When `npm run release` crashed and `grep v` matched nothing, the **inner pipeline failed but the outer `echo` succeeded**, so the step exited 0 with `TAG_NAME=""`. The release process then ran along a happy path that didn't exist. This is the "make CI step succeed even when it shouldn't" anti-pattern, and the workflow had it in two places.

## Fix (two parts in one PR)

### 1. Sync `.versions.json`

Added the missing workspace entries:
- `utils: "0.2.7"`
- `cli: "0.2.5"`
- `native-test: "0.1.0"`
- Also corrected `tailwind: "0.2.5"` → `"0.2.6"` (was stale by one patch)

All 8 current workspaces now covered.

### 2. Harden `prepare-release.yml` against silent failures

- **New pre-flight step `Validate .versions.json is in sync with workspaces`**. Runs before the releaser, walks `package.json#workspaces`, fails fast with a clear `::error::` message listing missing entries. Future workspace additions that forget `.versions.json` get caught immediately with a one-line actionable error instead of a TypeError 60 seconds in.

- **Rewrote `Prepare tag or release`** with `set -euo pipefail`, captures releaser output to `release-output.log`, extracts the tag with a strict regex (`^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)*` rather than `grep v`), and explicitly fails with a useful annotation if no tag was produced.

- **Same hardening on `Get generated package name`** — empty `*.tgz` directory now produces a clear error instead of `Input required and not supplied: path` two steps later.

- Fixed the long-standing typo `genereated` → `generated`.

## Verification

```
$ node -e "..."
.versions.json covers all 8 workspaces.
```

YAML still parses with 2 jobs. Workflow committed via the husky commit hook (lint-staged formatted both files).

## After merge

PR #151 (develop → main) auto-resyncs and `prepare-release` runs again. With Node 22 + a complete `.versions.json` + hardened error-surfacing, the releaser should:
- Walk all 71 commits since `v0.4.1-release`
- Bump versions across all affected packages (now including `utils`, `cli`, `native-test`)
- Pack `packages/icons` into `rocketicons-0.x.0.tgz`
- Append `-release` to the tag name (the icons package has substantive changes)
- Auto-push the `ci(releaser): bump packages versions...` commit onto develop
- Upload the deployable artifacts for the eventual `npm publish` on merge to main