### PR TITLE
chore(cicd): skip Vercel ignition deploys + ignore release-output.log

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -211,7 +211,15 @@ jobs:
           path: packages/data-helpers.tar
           compression-level: 9
 
+  # Ignition preview deploys to Vercel are temporarily disabled. The
+  # rocketicons.io project is being migrated off Vercel (AWS Amplify
+  # config exists in amplify.yml; final deploy target TBD), and the
+  # VERCEL_TOKEN org secret hasn't been rotated since May 2024 — leaving
+  # this enabled fails every release PR after the (otherwise successful)
+  # Prepare Artifacts job. Re-enable (or replace with the new deploy
+  # target) once the docs-site hosting decision lands.
   publish-ignition:
+    if: false
     needs: prepare-artifacts
     uses: ./.github/workflows/publish-ignition.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,9 +131,15 @@ jobs:
         id: get-dependency-hash
         run: echo "DEPENDENCY_HASH=$(npx --yes @rocketclimb/sh extract-dependencies)" >> $GITHUB_OUTPUT
 
+  # Ignition production deploys to Vercel are temporarily disabled —
+  # see prepare-release.yml for the full reason (Vercel migration in
+  # flight, stale VERCEL_TOKEN). The npm publish above is independent
+  # and still ships the rocketicons package on every -release tag.
+  # Re-enable (or swap in the new deploy target) once the docs-site
+  # hosting decision lands.
   publish-ignition:
     name: Publish Ignition without rocketicons release
-    if: needs.create-tag.outputs.is-release == 'false'
+    if: false
     needs:
       - create-tag
       - get-dependency-token
@@ -149,7 +155,7 @@ jobs:
 
   publish-ignition-for-release:
     name: Publish Ignition with rocketicons release
-    if: needs.create-tag.outputs.is-release == 'true'
+    if: false
     needs:
       - create-tag
       - create-release

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ packages/icons/*
 !packages/icons/package.json
 *.tgz
 release-notes.md
+release-output.log
 .DS_Store
 .vercel
 .env

--- a/release-output.log
+++ b/release-output.log
@@ -1,4 +1,0 @@
-
-> rocketclimb-icons@0.4.5 release
-> npx rocketclimb-sh releaser
-


### PR DESCRIPTION
## Summary

Disables the Vercel ignition-deploy jobs in `prepare-release.yml` and `release.yml` with `if: false` until the rocketicons.io hosting story is settled. Unblocks the v0.3.0 `rocketicons` release: the package will publish to npm cleanly, the Vercel preview/prod-deploy steps no longer fail every run.

## Context

While debugging the previous prepare-release runs we noticed:
- `amplify.yml` and `amplify/` exist in the repo (Amplify migration started)
- `VERCEL_TOKEN` org secret is from May 2024 (almost certainly expired)
- `rocketicons.io` currently returns `NXDOMAIN`
- The Vercel deploy job has been failing on every release attempt with no observable user impact

So Vercel-bound steps are pure noise right now. The `npm publish` step in `release.yml` runs in a completely separate job (`create-release`) and is unaffected by skipping `publish-ignition*`.

## Changes

- `prepare-release.yml`: `if: false` on the `publish-ignition` job (preview deploy), with inline reasoning
- `release.yml`: `if: false` on both `publish-ignition` and `publish-ignition-for-release` jobs
- `.gitignore`: add `release-output.log` (the temp file the hardened "Prepare tag or release" step writes to — got accidentally auto-pushed in commit `a4fbdd041` by the releaser, removing it from tracking here)

## Test plan

- [x] YAML still parses cleanly (verified locally)
- [ ] After merge, PR #151 (develop → main) re-runs `prepare-release` — expect `prepare-artifacts` ✓ + `publish-ignition` skipped (instead of failure)
- [ ] On merge to main, `release.yml` runs — expect tag created, npm publish succeeds, Vercel jobs skipped, GitHub Release created from `release-notes.md`

## Re-enabling

The `if: false` is intentionally on three jobs so it's easy to grep. When the hosting decision lands (Amplify, Coolify, or back to Vercel with a fresh token), drop the `if: false` lines, swap in the new deploy implementation in `publish-ignition.yml` if needed, rotate any stale tokens, done.