### PR TITLE
fix(cicd): upload .tagrc despite upload-artifact@v4 hiding dotfiles

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -183,6 +183,13 @@ jobs:
         with:
           name: tag-artifact
           path: .tagrc
+          # `.tagrc` is a dotfile; actions/upload-artifact@v4 skips
+          # hidden files by default (silently — only a warning, the step
+          # still reports success). Without this, the tag-artifact never
+          # lands, and release.yml's "Download tag artifact" step fails
+          # the entire npm publish flow on merge to main. See
+          # https://github.com/actions/upload-artifact/blob/main/README.md#hidden-files
+          include-hidden-files: true
 
       - name: Upload deployable artifacts to release job
         if: contains(steps.prepare-release.outputs.TAG_NAME, 'release')


### PR DESCRIPTION
## Summary

Pre-flight check on the v0.5.0-release pipeline caught a silent bug that would have blocked the actual npm publish on merge to main.

## What I found

The latest `prepare-release` run (25532192649, on develop after PR #155) reported all-green but **never uploaded the `tag-artifact`**. From its API artifact listing:

```
$ gh api repos/rocketclimb/rocketicons/actions/runs/25532192649/artifacts
total_count: 2
 - data-helpers
 - deployable-artifacts
```

Missing: `tag-artifact`. Yet `release.yml` does, on every push to main:

```yaml
- name: Download tag artifact
  uses: actions/download-artifact@v4
  with:
    name: tag-artifact
    ...
```

That step would have failed immediately, blocking the rest of the release.

## Root cause

`actions/upload-artifact@v4` silently skips hidden files unless `include-hidden-files: true` is set. The path is `.tagrc` (leading dot → hidden). The step exits "success" with only this warning in the log — easy to miss:

```
##[warning]No files were found with the provided path: .tagrc. No artifacts will be uploaded.
```

This is a v4 regression vs. earlier versions of the action. Other artifact uploads in the workflow (`release-notes.md`, `*.tgz`, `data-helpers.tar`) are fine because they're not dotfiles.

## Fix

One line + comment: `include-hidden-files: true` on the `tag-artifact` upload step. Inline comment links to `upload-artifact`'s documented hidden-file behavior so the next dotfile artifact doesn't trip the same wire.

## Verified pre-flight against the rest of release.yml

Once `tag-artifact` lands, every other step works:

- ✓ `tag-artifact` zip extracts to `.tagrc` containing `v0.5.0-release`
- ✓ `is-release` evaluates `true` → `create-release` job runs
- ✓ `deployable-artifacts` already uploaded correctly: `release-notes.md` (10885 bytes, comprehensive v0.5.0 changelog) + `rocketicons-0.3.0.tgz` (43MB, 331 files)
- ✓ Tarball's package.json: `name=rocketicons`, `version=0.3.0`, `engines.node=">=20"` — all correct
- ✓ npm publish via `NODE_AUTH_TOKEN=secrets.NPM_TOKEN` (rotated 2026-05-08, owned by `amorimjj` who maintains `rocketicons` on npm)
- ✓ Vercel jobs disabled per PR #155

## After merge

PR #151 (develop → main) auto-resyncs, prepare-release runs once more, this time uploading all 3 artifacts (`tag-artifact`, `deployable-artifacts`, `data-helpers`). Then merge to main is the actual publish trigger.