### PR TITLE
fix(ci): publish Cloudflare preview URLs on pull requests

### DIFF
--- a/.github/scripts/github-pages-preview.mjs
+++ b/.github/scripts/github-pages-preview.mjs
@@ -1,0 +1,171 @@
+import { pathToFileURL } from "node:url";
+
+const githubApiVersion = "2022-11-28";
+
+function repositoryPath(repository) {
+  const [owner, repo, extra] = repository.split("/");
+
+  if (!owner || !repo || extra) {
+    throw new Error(`Invalid GitHub repository: ${repository}`);
+  }
+
+  return `${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+}
+
+async function githubRequest(url, { token, fetchImpl, ...init }) {
+  const response = await fetchImpl(url, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": githubApiVersion,
+      ...init.headers
+    }
+  });
+  const responseText = await response.text();
+  const body = responseText ? JSON.parse(responseText) : null;
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed (${response.status})${body?.message ? `: ${body.message}` : ""}`
+    );
+  }
+
+  return body;
+}
+
+export async function publishGitHubPreview({
+  token,
+  repository,
+  ref,
+  environment,
+  environmentUrl,
+  runUrl,
+  fetchImpl = fetch
+}) {
+  const deploymentsUrl =
+    `https://api.github.com/repos/${repositoryPath(repository)}` + "/deployments";
+  const deployment = await githubRequest(deploymentsUrl, {
+    token,
+    fetchImpl,
+    method: "POST",
+    body: JSON.stringify({
+      ref,
+      task: "deploy",
+      auto_merge: false,
+      required_contexts: [],
+      environment,
+      description: "Cloudflare Pages preview",
+      transient_environment: true,
+      production_environment: false
+    })
+  });
+
+  await githubRequest(`${deploymentsUrl}/${encodeURIComponent(deployment.id)}/statuses`, {
+    token,
+    fetchImpl,
+    method: "POST",
+    body: JSON.stringify({
+      state: "success",
+      environment,
+      environment_url: environmentUrl,
+      log_url: runUrl,
+      description: "Cloudflare Pages preview is ready",
+      auto_inactive: true,
+      production_environment: false
+    })
+  });
+
+  console.log(`Published GitHub deployment ${deployment.id}: ${environmentUrl}`);
+  return { deploymentId: deployment.id };
+}
+
+export async function retireGitHubPreview({
+  token,
+  repository,
+  environment,
+  runUrl,
+  fetchImpl = fetch
+}) {
+  const deploymentsUrl = new URL(
+    `https://api.github.com/repos/${repositoryPath(repository)}/deployments`
+  );
+  deploymentsUrl.searchParams.set("environment", environment);
+  deploymentsUrl.searchParams.set("per_page", "1");
+
+  const deployments = await githubRequest(deploymentsUrl, { token, fetchImpl });
+  const [deployment] = deployments;
+
+  if (!deployment) {
+    console.log(`No GitHub deployment found for ${environment}`);
+    return { deploymentId: null };
+  }
+
+  await githubRequest(
+    `https://api.github.com/repos/${repositoryPath(repository)}` +
+      `/deployments/${encodeURIComponent(deployment.id)}/statuses`,
+    {
+      token,
+      fetchImpl,
+      method: "POST",
+      body: JSON.stringify({
+        state: "inactive",
+        environment,
+        log_url: runUrl,
+        description: "Cloudflare Pages preview retired",
+        production_environment: false
+      })
+    }
+  );
+
+  console.log(`Retired GitHub deployment ${deployment.id}`);
+  return { deploymentId: deployment.id };
+}
+
+function requireEnvironment(names) {
+  for (const name of names) {
+    if (!process.env[name]) {
+      throw new Error(`Missing required environment variable: ${name}`);
+    }
+  }
+}
+
+async function main() {
+  const commonEnvironment = [
+    "GITHUB_TOKEN",
+    "GITHUB_REPOSITORY",
+    "GITHUB_RUN_URL",
+    "PREVIEW_ACTION",
+    "PREVIEW_ENVIRONMENT"
+  ];
+  requireEnvironment(commonEnvironment);
+
+  const options = {
+    token: process.env.GITHUB_TOKEN,
+    repository: process.env.GITHUB_REPOSITORY,
+    environment: process.env.PREVIEW_ENVIRONMENT,
+    runUrl: process.env.GITHUB_RUN_URL
+  };
+
+  if (process.env.PREVIEW_ACTION === "publish") {
+    requireEnvironment(["PREVIEW_REF", "PREVIEW_URL"]);
+    await publishGitHubPreview({
+      ...options,
+      ref: process.env.PREVIEW_REF,
+      environmentUrl: process.env.PREVIEW_URL
+    });
+    return;
+  }
+
+  if (process.env.PREVIEW_ACTION === "retire") {
+    await retireGitHubPreview(options);
+    return;
+  }
+
+  throw new Error(`Unknown PREVIEW_ACTION: ${process.env.PREVIEW_ACTION}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/.github/scripts/github-pages-preview.test.mjs
+++ b/.github/scripts/github-pages-preview.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { publishGitHubPreview, retireGitHubPreview } from "./github-pages-preview.mjs";
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body)
+  };
+}
+
+test("publishes the stable preview URL as a transient GitHub deployment", async () => {
+  const requests = [];
+  const responses = [jsonResponse({ id: 1670 }, 201), jsonResponse({ id: 9001 }, 201)];
+  const fetchImpl = async (url, init = {}) => {
+    requests.push({
+      url: String(url),
+      method: init.method ?? "GET",
+      body: init.body ? JSON.parse(init.body) : null
+    });
+    return responses.shift();
+  };
+
+  const result = await publishGitHubPreview({
+    token: "test-token",
+    repository: "rocketclimb/rocketicons",
+    ref: "abc123",
+    environment: "pr-167",
+    environmentUrl: "https://pr-167.rocketicons.pages.dev",
+    runUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/42",
+    fetchImpl
+  });
+
+  assert.deepEqual(result, { deploymentId: 1670 });
+  assert.deepEqual(requests, [
+    {
+      url: "https://api.github.com/repos/rocketclimb/rocketicons/deployments",
+      method: "POST",
+      body: {
+        ref: "abc123",
+        task: "deploy",
+        auto_merge: false,
+        required_contexts: [],
+        environment: "pr-167",
+        description: "Cloudflare Pages preview",
+        transient_environment: true,
+        production_environment: false
+      }
+    },
+    {
+      url: "https://api.github.com/repos/rocketclimb/rocketicons/deployments/1670/statuses",
+      method: "POST",
+      body: {
+        state: "success",
+        environment: "pr-167",
+        environment_url: "https://pr-167.rocketicons.pages.dev",
+        log_url: "https://github.com/rocketclimb/rocketicons/actions/runs/42",
+        description: "Cloudflare Pages preview is ready",
+        auto_inactive: true,
+        production_environment: false
+      }
+    }
+  ]);
+});
+
+test("retires the latest GitHub deployment for a closed preview", async () => {
+  const requests = [];
+  const responses = [jsonResponse([{ id: 1670 }]), jsonResponse({ id: 9002 }, 201)];
+  const fetchImpl = async (url, init = {}) => {
+    requests.push({
+      url: String(url),
+      method: init.method ?? "GET",
+      body: init.body ? JSON.parse(init.body) : null
+    });
+    return responses.shift();
+  };
+
+  const result = await retireGitHubPreview({
+    token: "test-token",
+    repository: "rocketclimb/rocketicons",
+    environment: "pr-167",
+    runUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/43",
+    fetchImpl
+  });
+
+  assert.deepEqual(result, { deploymentId: 1670 });
+  assert.deepEqual(requests, [
+    {
+      url: "https://api.github.com/repos/rocketclimb/rocketicons/deployments?environment=pr-167&per_page=1",
+      method: "GET",
+      body: null
+    },
+    {
+      url: "https://api.github.com/repos/rocketclimb/rocketicons/deployments/1670/statuses",
+      method: "POST",
+      body: {
+        state: "inactive",
+        environment: "pr-167",
+        log_url: "https://github.com/rocketclimb/rocketicons/actions/runs/43",
+        description: "Cloudflare Pages preview retired",
+        production_environment: false
+      }
+    }
+  ]);
+});
+
+test("retiring is a no-op when no GitHub deployment exists", async () => {
+  const result = await retireGitHubPreview({
+    token: "test-token",
+    repository: "rocketclimb/rocketicons",
+    environment: "pr-167",
+    runUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/43",
+    fetchImpl: async () => jsonResponse([])
+  });
+
+  assert.deepEqual(result, { deploymentId: null });
+});

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -143,6 +143,17 @@ jobs:
           echo "### Cloudflare Pages preview" >> "$GITHUB_STEP_SUMMARY"
           echo "[$PREVIEW_URL]($PREVIEW_URL)" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Publish preview URL to GitHub
+        if: steps.deploy-preview.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PREVIEW_ACTION: publish
+          PREVIEW_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
+          PREVIEW_REF: ${{ github.event.pull_request.head.sha }}
+          PREVIEW_URL: ${{ steps.deploy-preview.outputs.pages-deployment-alias-url }}
+        run: node .github/scripts/github-pages-preview.mjs
+
   cleanup-preview:
     name: Retire closed PR preview
     if: >-
@@ -175,3 +186,11 @@ jobs:
           PREVIEW_BRANCH: pr-${{ github.event.pull_request.number }}
           KEEP_DEPLOYMENT_ID: ${{ steps.retire-preview.outputs.pages-deployment-id }}
         run: node .github/scripts/cleanup-pages-preview.mjs
+
+      - name: Retire GitHub preview deployment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PREVIEW_ACTION: retire
+          PREVIEW_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
+        run: node .github/scripts/github-pages-preview.mjs

--- a/packages/ignition/src/app/components/footer-years.test.ts
+++ b/packages/ignition/src/app/components/footer-years.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "@jest/globals";
+
+import { formatCopyrightYears } from "./footer-years";
+
+describe("footer copyright years", () => {
+  test("shows only the starting year during the first year", () => {
+    expect(formatCopyrightYears(2024)).toBe("2024");
+  });
+
+  test("shows a range after the starting year", () => {
+    expect(formatCopyrightYears(2026)).toBe("2024–2026");
+  });
+});

--- a/packages/ignition/src/app/components/footer-years.ts
+++ b/packages/ignition/src/app/components/footer-years.ts
@@ -1,0 +1,6 @@
+const COPYRIGHT_START_YEAR = 2024;
+
+export const formatCopyrightYears = (currentYear: number) =>
+  currentYear > COPYRIGHT_START_YEAR
+    ? `${COPYRIGHT_START_YEAR}–${currentYear}`
+    : `${COPYRIGHT_START_YEAR}`;

--- a/packages/ignition/src/app/components/footer.tsx
+++ b/packages/ignition/src/app/components/footer.tsx
@@ -3,14 +3,17 @@ import RocketClimbText from "@/app/components/rocketclimb-text";
 import { FaDiscord } from "rocketicons/fa";
 import Link from "next/link";
 import GitHubIcon from "@/app/components/github-icon";
+import { formatCopyrightYears } from "@/app/components/footer-years";
 
 const Footer = ({ className }: { className?: string }) => {
+  const copyrightYears = formatCopyrightYears(new Date().getFullYear());
+
   return (
     <footer className={`w-full mt-8 h-16 ${className}`}>
       <div className="px-4 pt-4 pb-5 border-t border-surface-border flex flex-row items-center text-primary-light dark:border-surface-border/5">
         <div className="grow">
           <p className="text-sm xs:text-base">
-            Copyright © 2024 <RocketClimbText />
+            Copyright © {copyrightYears} <RocketClimbText />
           </p>
         </div>
         <Link


### PR DESCRIPTION
## Preview

[Open the Cloudflare Pages preview](https://pr-167.rocketicons.pages.dev)

GitHub now tracks this as the successful transient `pr-167` deployment for the latest PR commit.

## Summary

- publish each successful Cloudflare PR preview as a native GitHub deployment with the stable alias as its environment URL
- mark the GitHub deployment inactive when the PR preview is retired
- keep the footer copyright range current at build time, providing a visible smoke test for preview deployments
- cover GitHub deployment publication, retirement, and footer year formatting with focused tests

## Root cause

`cloudflare/wrangler-action` returned the deployment and alias URLs, but its built-in GitHub integration did not create a deployment record. The workflow only copied the alias to `GITHUB_STEP_SUMMARY`, which is not discoverable from the PR itself.

The workflow now publishes the deployment record explicitly after Cloudflare succeeds instead of depending on optional Wrangler metadata parsing.

## Verification

- Cloudflare Pages run `33107544247` completed successfully for commit `7f651811`
- GitHub deployment `6129467992` is successful, transient, non-production, and links to the stable preview alias
- workspace CI: 15 suites and 111 tests passed
- focused deployment/cleanup checks: 6 tests passed
- focused footer checks: 2 tests passed
- English and Portuguese preview pages return HTTP 200 and render `Copyright © 2024–2026`
- preview responses include `x-robots-tag: noindex`
- production deployment and Algolia synchronization were skipped

The remaining lifecycle check is performed when this PR is merged or closed: Cloudflare should replace the preview with the retirement redirect, remove superseded deployments, and mark the GitHub deployment inactive.
