### PR TITLE
fix(ci): isolate preview retirement dependencies

### DIFF
--- a/.github/preview-closed/package.json
+++ b/.github/preview-closed/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "rocketicons-preview-closed",
+  "private": true
+}


### PR DESCRIPTION
## Summary
- make the closed-preview fixture an independent private npm package
- prevent Wrangler installation from walking up to the repository package and private dependencies

## Evidence
- the failed PR #168 close run reached the isolated working directory but npm still selected the ancestor package
- npm now resolves .github/preview-closed as its package root
- workflow formatting and YAML validation pass
- all six preview lifecycle helper tests pass

## Lifecycle test
This PR's opened run should publish a preview URL. After merge, its close run should retire the preview successfully; the manual recovery input can then clean PRs #167 and #168.