### PR TITLE
fix(ci): document and reliably retire previews

### DIFF
--- a/.github/scripts/github-pages-preview.mjs
+++ b/.github/scripts/github-pages-preview.mjs
@@ -1,6 +1,7 @@
 import { pathToFileURL } from "node:url";
 
 const githubApiVersion = "2022-11-28";
+const previewCommentMarker = "<!-- rocketicons-preview-deployment -->";
 
 function repositoryPath(repository) {
   const [owner, repo, extra] = repository.split("/");
@@ -99,8 +100,20 @@ export async function retireGitHubPreview({
 
   if (!deployment) {
     console.log(`No GitHub deployment found for ${environment}`);
-    return { deploymentId: null };
+    return {
+      deploymentId: null,
+      ref: null,
+      environmentUrl: null,
+      deploymentRunUrl: null
+    };
   }
+
+  const statuses = await githubRequest(
+    `https://api.github.com/repos/${repositoryPath(repository)}` +
+      `/deployments/${encodeURIComponent(deployment.id)}/statuses?per_page=1`,
+    { token, fetchImpl }
+  );
+  const [previousStatus] = statuses;
 
   await githubRequest(
     `https://api.github.com/repos/${repositoryPath(repository)}` +
@@ -120,7 +133,123 @@ export async function retireGitHubPreview({
   );
 
   console.log(`Retired GitHub deployment ${deployment.id}`);
-  return { deploymentId: deployment.id };
+  return {
+    deploymentId: deployment.id,
+    ref: deployment.sha ?? null,
+    environmentUrl: previousStatus?.environment_url ?? null,
+    deploymentRunUrl: previousStatus?.log_url ?? null
+  };
+}
+
+function tableValue(body, label) {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return body?.match(new RegExp(`^\\| ${escapedLabel} \\| (.+) \\|$`, "m"))?.[1] ?? null;
+}
+
+function linkedUrl(body) {
+  return body?.match(/\]\((https:\/\/[^)]+)\)/)?.[1] ?? null;
+}
+
+export function previewCommentBody({
+  state,
+  repository,
+  environment,
+  environmentUrl,
+  ref,
+  deploymentRunUrl,
+  lifecycleRunUrl,
+  existingBody = ""
+}) {
+  const ready = state === "ready";
+  const status = ready ? "Ready" : "Retired — the URL now redirects to production";
+  const previewUrl = environmentUrl ?? linkedUrl(existingBody);
+  const environmentCell = `\`${environment}\``;
+  const commitCell = ref
+    ? `[\`${ref.slice(0, 8)}\`](https://github.com/${repository}/commit/${ref})`
+    : tableValue(existingBody, "Commit");
+  const deploymentRunCell = deploymentRunUrl
+    ? `[View workflow run](${deploymentRunUrl})`
+    : tableValue(existingBody, "Deployment run");
+  const rows = [
+    `| Status | ${status} |`,
+    `| Environment | ${environmentCell} |`,
+    ...(commitCell ? [`| Commit | ${commitCell} |`] : []),
+    ...(deploymentRunCell ? [`| Deployment run | ${deploymentRunCell} |`] : []),
+    ...(!ready ? [`| Retirement run | [View workflow run](${lifecycleRunUrl}) |`] : [])
+  ];
+
+  return [
+    previewCommentMarker,
+    "### Preview deployment",
+    "",
+    previewUrl
+      ? `[${ready ? "Open preview" : "Recorded preview URL"}](${previewUrl})`
+      : "The preview URL was not recorded.",
+    "",
+    "| Detail | Value |",
+    "| --- | --- |",
+    ...rows,
+    "",
+    "This comment is managed by the preview deployment workflow and remains as deployment history."
+  ].join("\n");
+}
+
+export async function upsertPreviewComment({
+  token,
+  repository,
+  pullRequestNumber,
+  state,
+  environment,
+  environmentUrl,
+  ref,
+  deploymentRunUrl,
+  lifecycleRunUrl,
+  fetchImpl = fetch
+}) {
+  const issueCommentsUrl =
+    `https://api.github.com/repos/${repositoryPath(repository)}` +
+    `/issues/${encodeURIComponent(pullRequestNumber)}/comments`;
+  const comments = await githubRequest(`${issueCommentsUrl}?per_page=100`, {
+    token,
+    fetchImpl
+  });
+  const existingComment = comments.find(
+    (comment) => comment.user?.type === "Bot" && comment.body?.includes(previewCommentMarker)
+  );
+  const body = previewCommentBody({
+    state,
+    repository,
+    environment,
+    environmentUrl,
+    ref,
+    deploymentRunUrl,
+    lifecycleRunUrl,
+    existingBody: existingComment?.body
+  });
+
+  if (existingComment) {
+    await githubRequest(
+      `https://api.github.com/repos/${repositoryPath(repository)}` +
+        `/issues/comments/${encodeURIComponent(existingComment.id)}`,
+      {
+        token,
+        fetchImpl,
+        method: "PATCH",
+        body: JSON.stringify({ body })
+      }
+    );
+    console.log(`Updated preview comment ${existingComment.id}`);
+    return { commentId: existingComment.id };
+  }
+
+  const comment = await githubRequest(issueCommentsUrl, {
+    token,
+    fetchImpl,
+    method: "POST",
+    body: JSON.stringify({ body })
+  });
+  console.log(`Created preview comment ${comment.id}`);
+  return { commentId: comment.id };
 }
 
 function requireEnvironment(names) {
@@ -137,7 +266,8 @@ async function main() {
     "GITHUB_REPOSITORY",
     "GITHUB_RUN_URL",
     "PREVIEW_ACTION",
-    "PREVIEW_ENVIRONMENT"
+    "PREVIEW_ENVIRONMENT",
+    "PREVIEW_PR_NUMBER"
   ];
   requireEnvironment(commonEnvironment);
 
@@ -155,11 +285,29 @@ async function main() {
       ref: process.env.PREVIEW_REF,
       environmentUrl: process.env.PREVIEW_URL
     });
+    await upsertPreviewComment({
+      ...options,
+      pullRequestNumber: process.env.PREVIEW_PR_NUMBER,
+      state: "ready",
+      environmentUrl: process.env.PREVIEW_URL,
+      ref: process.env.PREVIEW_REF,
+      deploymentRunUrl: process.env.GITHUB_RUN_URL,
+      lifecycleRunUrl: process.env.GITHUB_RUN_URL
+    });
     return;
   }
 
   if (process.env.PREVIEW_ACTION === "retire") {
-    await retireGitHubPreview(options);
+    const retirement = await retireGitHubPreview(options);
+    await upsertPreviewComment({
+      ...options,
+      pullRequestNumber: process.env.PREVIEW_PR_NUMBER,
+      state: "retired",
+      environmentUrl: retirement.environmentUrl ?? process.env.PREVIEW_URL,
+      ref: retirement.ref ?? process.env.PREVIEW_REF,
+      deploymentRunUrl: retirement.deploymentRunUrl,
+      lifecycleRunUrl: process.env.GITHUB_RUN_URL
+    });
     return;
   }
 

--- a/.github/scripts/github-pages-preview.test.mjs
+++ b/.github/scripts/github-pages-preview.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { publishGitHubPreview, retireGitHubPreview } from "./github-pages-preview.mjs";
+import {
+  previewCommentBody,
+  publishGitHubPreview,
+  retireGitHubPreview,
+  upsertPreviewComment
+} from "./github-pages-preview.mjs";
 
 function jsonResponse(body, status = 200) {
   return {
@@ -67,7 +72,16 @@ test("publishes the stable preview URL as a transient GitHub deployment", async 
 
 test("retires the latest GitHub deployment for a closed preview", async () => {
   const requests = [];
-  const responses = [jsonResponse([{ id: 1670 }]), jsonResponse({ id: 9002 }, 201)];
+  const responses = [
+    jsonResponse([{ id: 1670, sha: "abc123" }]),
+    jsonResponse([
+      {
+        environment_url: "https://pr-167.rocketicons.pages.dev",
+        log_url: "https://github.com/rocketclimb/rocketicons/actions/runs/42"
+      }
+    ]),
+    jsonResponse({ id: 9002 }, 201)
+  ];
   const fetchImpl = async (url, init = {}) => {
     requests.push({
       url: String(url),
@@ -85,10 +99,20 @@ test("retires the latest GitHub deployment for a closed preview", async () => {
     fetchImpl
   });
 
-  assert.deepEqual(result, { deploymentId: 1670 });
+  assert.deepEqual(result, {
+    deploymentId: 1670,
+    ref: "abc123",
+    environmentUrl: "https://pr-167.rocketicons.pages.dev",
+    deploymentRunUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/42"
+  });
   assert.deepEqual(requests, [
     {
       url: "https://api.github.com/repos/rocketclimb/rocketicons/deployments?environment=pr-167&per_page=1",
+      method: "GET",
+      body: null
+    },
+    {
+      url: "https://api.github.com/repos/rocketclimb/rocketicons/deployments/1670/statuses?per_page=1",
       method: "GET",
       body: null
     },
@@ -115,5 +139,103 @@ test("retiring is a no-op when no GitHub deployment exists", async () => {
     fetchImpl: async () => jsonResponse([])
   });
 
-  assert.deepEqual(result, { deploymentId: null });
+  assert.deepEqual(result, {
+    deploymentId: null,
+    ref: null,
+    environmentUrl: null,
+    deploymentRunUrl: null
+  });
+});
+
+test("creates one durable PR comment when a preview becomes ready", async () => {
+  const requests = [];
+  const responses = [jsonResponse([]), jsonResponse({ id: 1700 }, 201)];
+  const fetchImpl = async (url, init = {}) => {
+    requests.push({
+      url: String(url),
+      method: init.method ?? "GET",
+      body: init.body ? JSON.parse(init.body) : null
+    });
+    return responses.shift();
+  };
+  const options = {
+    token: "test-token",
+    repository: "rocketclimb/rocketicons",
+    pullRequestNumber: "170",
+    state: "ready",
+    environment: "pr-170",
+    environmentUrl: "https://pr-170.rocketicons.pages.dev",
+    ref: "abcdef123456",
+    deploymentRunUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/50",
+    lifecycleRunUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/50",
+    fetchImpl
+  };
+
+  const result = await upsertPreviewComment(options);
+
+  assert.deepEqual(result, { commentId: 1700 });
+  assert.deepEqual(requests, [
+    {
+      url: "https://api.github.com/repos/rocketclimb/rocketicons/issues/170/comments?per_page=100",
+      method: "GET",
+      body: null
+    },
+    {
+      url: "https://api.github.com/repos/rocketclimb/rocketicons/issues/170/comments",
+      method: "POST",
+      body: {
+        body: previewCommentBody(options)
+      }
+    }
+  ]);
+});
+
+test("updates the same PR comment on retirement and preserves deployment history", async () => {
+  const readyBody = previewCommentBody({
+    state: "ready",
+    repository: "rocketclimb/rocketicons",
+    environment: "pr-170",
+    environmentUrl: "https://pr-170.rocketicons.pages.dev",
+    ref: "abcdef123456",
+    deploymentRunUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/50",
+    lifecycleRunUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/50"
+  });
+  const requests = [];
+  const responses = [
+    jsonResponse([{ id: 1700, user: { type: "Bot" }, body: readyBody }]),
+    jsonResponse({ id: 1700 })
+  ];
+  const fetchImpl = async (url, init = {}) => {
+    requests.push({
+      url: String(url),
+      method: init.method ?? "GET",
+      body: init.body ? JSON.parse(init.body) : null
+    });
+    return responses.shift();
+  };
+
+  const result = await upsertPreviewComment({
+    token: "test-token",
+    repository: "rocketclimb/rocketicons",
+    pullRequestNumber: "170",
+    state: "retired",
+    environment: "pr-170",
+    environmentUrl: null,
+    ref: null,
+    deploymentRunUrl: null,
+    lifecycleRunUrl: "https://github.com/rocketclimb/rocketicons/actions/runs/51",
+    fetchImpl
+  });
+
+  assert.deepEqual(result, { commentId: 1700 });
+  assert.equal(requests[1].method, "PATCH");
+  assert.equal(
+    requests[1].url,
+    "https://api.github.com/repos/rocketclimb/rocketicons/issues/comments/1700"
+  );
+  assert.match(requests[1].body.body, /Recorded preview URL/);
+  assert.match(requests[1].body.body, /Retired — the URL now redirects to production/);
+  assert.match(requests[1].body.body, /abcdef12/);
+  assert.match(requests[1].body.body, /actions\/runs\/50/);
+  assert.match(requests[1].body.body, /actions\/runs\/51/);
 });

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,7 @@ permissions:
   contents: read
   packages: read
   deployments: write
+  pull-requests: write
 
 concurrency:
   group: >-
@@ -157,6 +158,7 @@ jobs:
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PREVIEW_ACTION: publish
           PREVIEW_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
+          PREVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
           PREVIEW_REF: ${{ github.event.pull_request.head.sha }}
           PREVIEW_URL: ${{ steps.deploy-preview.outputs.pages-deployment-alias-url }}
         run: node .github/scripts/github-pages-preview.mjs
@@ -214,4 +216,7 @@ jobs:
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PREVIEW_ACTION: retire
           PREVIEW_ENVIRONMENT: pr-${{ env.PREVIEW_PR_NUMBER }}
+          PREVIEW_PR_NUMBER: ${{ env.PREVIEW_PR_NUMBER }}
+          PREVIEW_REF: ${{ github.event.pull_request.head.sha }}
+          PREVIEW_URL: https://pr-${{ env.PREVIEW_PR_NUMBER }}.rocketicons.pages.dev
         run: node .github/scripts/github-pages-preview.mjs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -178,6 +178,13 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
 
+      # Wrangler Action installs Wrangler from the checkout root even when its
+      # command runs in a working directory, so its install needs package auth.
+      - name: Configure GitHub Packages
+        run: |
+          npm config set @rocketclimb:registry https://npm.pkg.github.com
+          npm config set //npm.pkg.github.com/:_authToken ${{ github.token }}
+
       - name: Validate preview PR number
         run: '[[ "$PREVIEW_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]'
 


### PR DESCRIPTION
## Summary
- authenticate GitHub Packages before Wrangler Action installs from the checkout root
- keep one workflow-managed preview comment in every internal PR
- preserve the preview URL, commit, and deployment run after closure
- update that same comment to Retired when cleanup succeeds

## Root cause
Wrangler Action respects workingDirectory for the Pages command, but its automatic Wrangler installation still runs against the checkout root. The root includes the private @rocketclimb/sh package, so closed-PR cleanup needs package authentication.

## Validation
- workflow YAML and formatting pass
- all eight preview lifecycle tests pass
- run 33114254976 passed all workspace tests, export, preview deployment, native GitHub deployment, and PR comment publication
- PR #170 has one Ready comment from github-actions[bot] linking https://pr-170.rocketicons.pages.dev

## Close acceptance
After merge, the close run must retire Cloudflare and GitHub deployments and update the same PR comment to Retired. The manual recovery input will then clean PRs #167-#169.