### PR TITLE
fix(ci): use supported Pages cleanup pagination

### DIFF
--- a/.github/scripts/cleanup-pages-preview.mjs
+++ b/.github/scripts/cleanup-pages-preview.mjs
@@ -53,7 +53,6 @@ export async function cleanupPagesPreview({
       const url = new URL(baseUrl);
       url.searchParams.set("env", "preview");
       url.searchParams.set("page", String(page));
-      url.searchParams.set("per_page", "50");
 
       const body = await cloudflareRequest(url);
       deployments.push(...body.result);

--- a/.github/scripts/cleanup-pages-preview.test.mjs
+++ b/.github/scripts/cleanup-pages-preview.test.mjs
@@ -54,6 +54,15 @@ test("deletes superseded deployments only for the retired PR branch", async () =
 
   assert.deepEqual(result.deleted, ["old"]);
   assert.deepEqual(
+    requests.filter(({ method }) => method === "GET"),
+    [
+      {
+        method: "GET",
+        url: "https://api.cloudflare.com/client/v4/accounts/account/pages/projects/rocketicons/deployments?env=preview&page=1"
+      }
+    ]
+  );
+  assert.deepEqual(
     requests.filter(({ method }) => method === "DELETE"),
     [
       {


### PR DESCRIPTION
## Summary
- let Cloudflare Pages use its supported default deployment page size
- retain explicit page traversal through result_info.total_pages
- assert the exact list request in the cleanup test

## Root cause
PR #170's close run successfully deployed the retirement redirect, then Cloudflare rejected per_page=50 with API error 8000024.

## Validation
- all eight preview deployment, durable-comment, and cleanup tests pass
- workflow YAML and formatting pass
- after merge, this PR's close run must complete cleanup and update its durable comment to Retired
- manual recovery runs will then clean PRs #167-#170