### PR TITLE
fix(ci): use valid Pages list options

### DIFF
--- a/.github/scripts/cleanup-pages-preview.mjs
+++ b/.github/scripts/cleanup-pages-preview.mjs
@@ -53,6 +53,7 @@ export async function cleanupPagesPreview({
       const url = new URL(baseUrl);
       url.searchParams.set("env", "preview");
       url.searchParams.set("page", String(page));
+      url.searchParams.set("per_page", "20");
 
       const body = await cloudflareRequest(url);
       deployments.push(...body.result);

--- a/.github/scripts/cleanup-pages-preview.test.mjs
+++ b/.github/scripts/cleanup-pages-preview.test.mjs
@@ -58,7 +58,7 @@ test("deletes superseded deployments only for the retired PR branch", async () =
     [
       {
         method: "GET",
-        url: "https://api.cloudflare.com/client/v4/accounts/account/pages/projects/rocketicons/deployments?env=preview&page=1"
+        url: "https://api.cloudflare.com/client/v4/accounts/account/pages/projects/rocketicons/deployments?env=preview&page=1&per_page=20"
       }
     ]
   );

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -202,6 +202,7 @@ jobs:
           command: pages deploy . --project-name=rocketicons --branch=pr-${{ env.PREVIEW_PR_NUMBER }}
 
       - name: Delete superseded preview deployments
+        id: delete-previews
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -211,6 +212,7 @@ jobs:
         run: node .github/scripts/cleanup-pages-preview.mjs
 
       - name: Retire GitHub preview deployment
+        if: always() && steps.retire-preview.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary
- request Cloudflare Pages deployments with page=1 and the documented/default-sized per_page=20
- continue paginating through result_info.total_pages
- retire GitHub's deployment and durable PR comment after the stable URL is retired, even if later history deletion fails

## Root cause
Cloudflare rejected page=1 without a page size and had previously rejected per_page=50. Its API example/default uses 20.

## Validation
- all eight preview deployment, durable-comment, and cleanup tests pass
- the cleanup test asserts the exact list request
- workflow YAML and formatting pass
- after merge, the close run must retire PR #172 end to end; recovery runs then retire PRs #167-#171