### PR TITLE
fix(ignition): correct search placeholder typo

### DIFF
--- a/packages/ignition/src/app/locales/en.json
+++ b/packages/ignition/src/app/locales/en.json
@@ -31,7 +31,7 @@
     "planned": "Planned"
   },
   "search": {
-    "placeholder": "Quick seach",
+    "placeholder": "Quick search",
     "no-results": "No results found"
   },
   "colors": "Colors",


### PR DESCRIPTION
## Summary
- correct the English homepage search label from “Quick seach” to “Quick search”
- provide a minimal visible change for reviewing the new preview deployment experience

## Validation
- locale JSON parses successfully
- Prettier check passes
- Git whitespace validation passes

## Preview review
Once the deployment finishes, use the managed preview comment on this PR to compare the English homepage search button. This PR is intentionally being left open for review.