### PR TITLE
fix(ci): trigger previews when pull requests become ready

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Cloudflare Pages
 on:
   pull_request:
     branches: [develop, main]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened, ready_for_review, closed]
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
The Pages workflow on develop already publishes a preview URL, deployment record, and durable PR comment. However, marking a draft ready for review does not trigger that workflow, so a draft's missing or failed preview is not refreshed at that point.

Add `ready_for_review` to the existing pull-request events. This uses develop's existing deployment and comment lifecycle without adding a second reporter or changing permissions.

Validation: all 5 existing GitHub preview lifecycle tests pass; workflow YAML parses and retains the existing preview publisher; `git diff --check` passes. The PR changes one line in one file and targets develop for the normal release flow.
