### PR TITLE
feat(ignition): per-icon titles on shared collection links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -116,6 +116,8 @@ jobs:
           test -f packages/ignition/out/img/og/en/home.png
           test -f packages/ignition/out/img/og/en/collections/wi.png
           test -f packages/ignition/out/img/og/pt-br/collections/wi.png
+          test -f packages/ignition/out/_worker.js
+          test -f packages/ignition/out/_routes.json
           size_kib=$(du -sk packages/ignition/out | cut -f1)
           test "$size_kib" -le 921600
           echo "Export size: $size_kib KiB"

--- a/packages/ignition/.gitignore
+++ b/packages/ignition/.gitignore
@@ -32,6 +32,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# wrangler local dev state
+.wrangler
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/packages/ignition/package.json
+++ b/packages/ignition/package.json
@@ -7,6 +7,7 @@
     "prebuild:cc": "if [ -z \"$SKIP_GENERATE_CONTENT_COLLECTIONS\" ]; then npm run generate-content-collections; else echo '[IGNITION] skip content collections generate'; fi",
     "prebuild:gs": "if [ -z \"$SKIP_GENERATE_IGNITION_STATICS\" ]; then npm run generate-statics; else echo '[IGNITION] skip statics generate'; fi",
     "build": "if [ -z \"$SKIP_IGNITION_BUILD\" ]; then NODE_PATH=./node_modules GENERATE_ALL_ICONS=$GENERATE_ALL_ICONS GENERATE_SAMPLE_ICONS=$GENERATE_SAMPLE_ICONS next build; else echo '[IGNITION] skip build'; fi",
+    "postbuild": "npx ts-node -r tsconfig-paths/register ./scripts/build-worker.ts",
     "build:static-full": "RI_GENERATE_ALL_ICONS=true npm run build",
     "build:static-sample": "npm run build",
     "predev": "npm run generate-content-collections && npm run generate-statics",

--- a/packages/ignition/scripts/build-worker.ts
+++ b/packages/ignition/scripts/build-worker.ts
@@ -1,0 +1,56 @@
+/**
+ * Bundles the Pages Worker into the static export.
+ *
+ * Cloudflare Pages picks up `_worker.js` from the deployed directory, and `_routes.json`
+ * decides which requests reach it. Scoping it to the collection pages means static assets are
+ * served directly and never spend a Worker invocation, which is what keeps this inside the
+ * free plan's 100k requests/day.
+ */
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { build } from "esbuild";
+
+import { siteConfig } from "../src/config/site";
+import { AvailableLanguages } from "../src/app/types/languages";
+
+const OUT_DIR = resolve("./out");
+const ENTRY = resolve("./src/worker/index.ts");
+
+const routes = {
+  version: 1,
+  include: AvailableLanguages.map((lang) => `/${lang}/icons/*`),
+  exclude: []
+};
+
+const main = async () => {
+  if (!existsSync(OUT_DIR)) {
+    console.log("[IGNITION] no export found, skipping worker build");
+    return;
+  }
+
+  await mkdir(OUT_DIR, { recursive: true });
+  await build({
+    entryPoints: [ENTRY],
+    outfile: resolve(OUT_DIR, "_worker.js"),
+    bundle: true,
+    format: "esm",
+    target: "es2022",
+    platform: "neutral",
+    minify: true,
+    // The worker cannot import site config directly: it reads process.env, which Workers lack.
+    define: { SITE_NAME: JSON.stringify(siteConfig.name) }
+  });
+
+  await writeFile(
+    resolve(OUT_DIR, "_routes.json"),
+    `${JSON.stringify(routes, null, 2)}\n`,
+    "utf8"
+  );
+  console.log(`[IGNITION] worker bundled; routes: ${routes.include.join(", ")}`);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/ignition/src/worker/cloudflare.d.ts
+++ b/packages/ignition/src/worker/cloudflare.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Minimal ambient declarations for the Cloudflare globals this Worker uses. Hand-rolled rather
+ * than pulling in @cloudflare/workers-types, whose globals (Request, Response, caches) collide
+ * with the DOM lib the rest of the app is typechecked against.
+ */
+
+interface Fetcher {
+  fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+}
+
+interface HTMLRewriterElement {
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  setInnerContent(content: string): void;
+}
+
+interface HTMLRewriterElementHandler {
+  element?(element: HTMLRewriterElement): void;
+}
+
+declare class HTMLRewriter {
+  on(selector: string, handler: HTMLRewriterElementHandler): HTMLRewriter;
+  transform(response: Response): Response;
+}
+
+/** Injected at bundle time by scripts/build-worker.ts. */
+declare const SITE_NAME: string;

--- a/packages/ignition/src/worker/index.ts
+++ b/packages/ignition/src/worker/index.ts
@@ -1,0 +1,93 @@
+import {
+  ICON_PARAM,
+  collectionNameFromIndex,
+  iconDescription,
+  iconDisplayName,
+  iconTitle,
+  iconUrl,
+  indexContainsIcon,
+  isWellFormedIconId,
+  matchCollectionPath
+} from "./og-icon-meta";
+
+type Env = { ASSETS: Fetcher };
+
+/**
+ * Collection indexes reach 1 MB, so hold only a couple per isolate — enough to spare repeat
+ * fetches on a hot collection without risking the 128 MB memory ceiling.
+ */
+const INDEX_CACHE_SIZE = 3;
+const indexCache = new Map<string, string>();
+
+const collectionIndex = async (env: Env, origin: string, collectionId: string) => {
+  const cached = indexCache.get(collectionId);
+  if (cached !== undefined) return cached;
+
+  const response = await env.ASSETS.fetch(
+    new Request(`${origin}/ai/v1/collections/${collectionId}/index.json`)
+  );
+  if (!response.ok) return undefined;
+
+  const text = await response.text();
+  if (indexCache.size >= INDEX_CACHE_SIZE) {
+    indexCache.delete(indexCache.keys().next().value as string);
+  }
+  indexCache.set(collectionId, text);
+  return text;
+};
+
+const setContent = (value: string) => ({
+  element(element: HTMLRewriterElement) {
+    element.setAttribute("content", value);
+  }
+});
+
+const worker = {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const iconId = url.searchParams.get(ICON_PARAM);
+    const route = matchCollectionPath(url.pathname);
+
+    // Anything that is not an icon deep link is served straight from the static export.
+    if (!iconId || !route || !isWellFormedIconId(iconId)) return env.ASSETS.fetch(request);
+
+    const response = await env.ASSETS.fetch(request);
+    if (!response.headers.get("content-type")?.includes("text/html")) return response;
+
+    const index = await collectionIndex(env, url.origin, route.collectionId);
+    if (!index || !indexContainsIcon(index, iconId)) return response;
+
+    const collectionName = collectionNameFromIndex(index);
+    if (!collectionName) return response;
+
+    const iconName = iconDisplayName(iconId);
+    const title = iconTitle(iconName, collectionName, SITE_NAME);
+    const description = iconDescription(iconName, collectionName, SITE_NAME);
+
+    return (
+      new HTMLRewriter()
+        .on("title", {
+          element(element) {
+            element.setInnerContent(title);
+          }
+        })
+        .on('meta[property="og:title"]', setContent(title))
+        .on('meta[name="twitter:title"]', setContent(title))
+        .on('meta[property="og:description"]', setContent(description))
+        .on('meta[name="twitter:description"]', setContent(description))
+        .on('meta[property="og:image:alt"]', setContent(title))
+        .on('meta[name="twitter:image:alt"]', setContent(title))
+        // Keep the shared link pointing at the selected icon. `canonical` stays on the
+        // collection on purpose, so 51k query variants are never indexed separately.
+        .on('meta[property="og:url"]', {
+          element(element) {
+            const next = iconUrl(element.getAttribute("content") ?? "", iconId);
+            if (next) element.setAttribute("content", next);
+          }
+        })
+        .transform(response)
+    );
+  }
+};
+
+export default worker;

--- a/packages/ignition/src/worker/og-icon-meta.test.ts
+++ b/packages/ignition/src/worker/og-icon-meta.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  collectionNameFromIndex,
+  iconDescription,
+  iconDisplayName,
+  iconTitle,
+  iconUrl,
+  indexContainsIcon,
+  isWellFormedIconId,
+  matchCollectionPath
+} from "./og-icon-meta";
+
+const COLLECTION = "Font Awesome 6";
+const SITE = "rocketicons";
+
+describe("per-icon card metadata", () => {
+  test("only collection pages are rewritten", () => {
+    expect(matchCollectionPath("/en/icons/fa6/")).toEqual({ lang: "en", collectionId: "fa6" });
+    expect(matchCollectionPath("/pt-br/icons/wi")).toEqual({ lang: "pt-br", collectionId: "wi" });
+    expect(matchCollectionPath("/en/icons/")).toBeUndefined();
+    expect(matchCollectionPath("/en/docs/colors/")).toBeUndefined();
+    expect(matchCollectionPath("/fr/icons/fa6/")).toBeUndefined();
+  });
+
+  test("rejects input that could inject text into a shared card", () => {
+    // The card links to rocketicons.com, so an attacker-chosen title would be misleading.
+    expect(isWellFormedIconId("fa-accessible-icon")).toBe(true);
+    expect(isWellFormedIconId("free bitcoin click here")).toBe(false);
+    expect(isWellFormedIconId("Fa-Accessible")).toBe(false);
+    expect(isWellFormedIconId("noseparator")).toBe(false);
+    expect(isWellFormedIconId(`fa-${"x".repeat(80)}`)).toBe(false);
+  });
+
+  test("existence check does not false-positive on a shared prefix", () => {
+    const index = '{"icons":[{"id":"fa-0-circle","name":"0 circle"},{"id":"fa-acorn"}]}';
+
+    expect(indexContainsIcon(index, "fa-0-circle")).toBe(true);
+    // "fa-0" is a real icon elsewhere; it must not match because of the closing quote.
+    expect(indexContainsIcon(index, "fa-0")).toBe(false);
+    expect(indexContainsIcon(index, "fa-nope")).toBe(false);
+  });
+
+  test("derives the display name the way the site titles it", () => {
+    expect(iconDisplayName("fa-accessible-icon")).toBe("Accessible Icon");
+    expect(iconDisplayName("wi-day-sunny")).toBe("Day Sunny");
+    expect(iconDisplayName("fa-0")).toBe("0");
+    expect(iconDisplayName("rocket")).toBe("Rocket");
+  });
+
+  test("leads with the icon and drops the tagline so the title still fits a card", () => {
+    const title = iconTitle("Accessible Icon", COLLECTION, SITE);
+
+    expect(title).toBe("Accessible Icon | Font Awesome 6 | rocketicons");
+    expect(title.length).toBeLessThan(60);
+  });
+
+  test("description names the icon and its collection", () => {
+    expect(iconDescription("Accessible Icon", COLLECTION, SITE)).toBe(
+      "Accessible Icon from Font Awesome 6. Add the React or React Native component to your project with rocketicons."
+    );
+  });
+
+  test("reads the collection name from the index without parsing it", () => {
+    const index =
+      '{"schemaVersion":1,"collection":{"id":"fa6","name":"Font Awesome 6","totalIcons":2058,' +
+      '"contextCoverage":{"total":2058}},"icons":[{"id":"fa-acorn"}]}';
+
+    expect(collectionNameFromIndex(index)).toBe("Font Awesome 6");
+    expect(collectionNameFromIndex("{}")).toBeUndefined();
+  });
+
+  test("builds the shared URL from the page origin, not the request host", () => {
+    // A preview or *.pages.dev host must not leak into the card's link.
+    expect(iconUrl("https://rocketicons.com/en/icons/fa6/", "fa-accessible-icon")).toBe(
+      "https://rocketicons.com/en/icons/fa6/?icon=fa-accessible-icon"
+    );
+    expect(iconUrl("not a url", "fa-acorn")).toBeUndefined();
+  });
+});

--- a/packages/ignition/src/worker/og-icon-meta.ts
+++ b/packages/ignition/src/worker/og-icon-meta.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-icon social card metadata.
+ *
+ * Icons are a query parameter on a statically exported collection page, so every `?icon=` URL
+ * shares one HTML file and cannot carry its own meta tags. These helpers let the Pages Worker
+ * rewrite the title and description per request. The image stays the collection's — rendering
+ * a per-icon PNG needs far more than the 10 ms CPU a Worker gets on the free plan.
+ */
+
+export const ICON_PARAM = "icon";
+
+/** Collection pages, the only routes worth rewriting. */
+const COLLECTION_PATH = /^\/(en|pt-br)\/icons\/([^/]+)\/?$/;
+
+export type CollectionRoute = { lang: string; collectionId: string };
+
+export const matchCollectionPath = (pathname: string): CollectionRoute | undefined => {
+  const match = COLLECTION_PATH.exec(pathname);
+  return match ? { lang: match[1], collectionId: match[2] } : undefined;
+};
+
+/**
+ * Shape guard applied before the value is looked up. Existence is still checked against the
+ * collection index — this only cheaply rejects input that could never be an icon id, so a
+ * crafted `?icon=` cannot put arbitrary text into a card that links to rocketicons.com.
+ */
+export const isWellFormedIconId = (value: string) =>
+  value.length <= 64 && /^[a-z0-9]+(?:-[a-z0-9]+)+$/.test(value);
+
+/**
+ * Existence check against the collection index without `JSON.parse`.
+ *
+ * The index is written compact, so ids appear verbatim as `"id":"fa-0"`. Parsing the largest
+ * index (Phosphor, 1 MB) costs ~2.9 ms against a 10 ms budget; a substring scan costs ~0.002 ms.
+ */
+export const indexContainsIcon = (indexText: string, iconId: string) =>
+  indexText.includes(`"id":"${iconId}"`);
+
+/** `fa-accessible-icon` -> `Accessible Icon`, matching how the site titles an icon. */
+export const iconDisplayName = (iconId: string) => {
+  const withoutPrefix = iconId.split("-").slice(1).join(" ") || iconId;
+  return withoutPrefix.replace(/(^|\s)([a-z0-9])/g, (_, lead, char) => lead + char.toUpperCase());
+};
+
+/**
+ * Reads the collection's display name out of the index without parsing it. `name` is the second
+ * field of the `collection` object, before any nested object, so the match cannot run past it.
+ */
+export const collectionNameFromIndex = (indexText: string) =>
+  /"collection":\{[^}]*?"name":"([^"]*)"/.exec(indexText)?.[1];
+
+/**
+ * The built title is `{Collection} | {site} | {tagline}`. Lead with the icon and drop the
+ * tagline, so the card still fits the ~60 characters most clients show.
+ */
+export const iconTitle = (iconName: string, collectionName: string, siteName: string) =>
+  [iconName, collectionName, siteName].filter(Boolean).join(" | ");
+
+export const iconDescription = (iconName: string, collectionName: string, siteName: string) =>
+  `${iconName} from ${collectionName}. Add the React or React Native component to your project with ${siteName}.`;
+
+/**
+ * Appends the icon to the page's own canonical URL rather than using the request URL, so the
+ * card keeps pointing at the production origin no matter which host served it.
+ */
+export const iconUrl = (pageUrl: string, iconId: string) => {
+  try {
+    const url = new URL(pageUrl);
+    url.searchParams.set(ICON_PARAM, iconId);
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
> **Stacked on #192** (`programad/dynamic-og-images-cloudflare`), so the diff below is just this feature. GitHub retargets it to `develop` when #192 merges.

## What and why

Sharing a link to a specific icon showed the collection's card, not the icon's:

```
/en/icons/fa6/?icon=fa-accessible-icon
  title -> "Font Awesome 6 | rocketicons | Add only what you use"
```

Icons are a **query parameter** on a statically exported collection page. Every `?icon=` URL is the same HTML file, so it cannot carry its own meta tags — no amount of build-time work fixes that. The tag has to be written per request.

This adds a Pages Worker that rewrites `<title>`, `og:title`, `og:description`, `twitter:*` and the image alts when `?icon=` is present:

```
/en/icons/fa6/?icon=fa-accessible-icon
  title -> "Accessible Icon | Font Awesome 6 | rocketicons"
  desc  -> "Accessible Icon from Font Awesome 6. Add the React or React Native component…"
```

## What it deliberately does not do

**The image stays the collection's.** Rendering a per-icon PNG needs satori + resvg, whose cold renders run **0.5–1.1 s of CPU** against the Workers free plan's **10 ms per-invocation ceiling** ([limits](https://developers.cloudflare.com/workers/platform/limits/)). Caching does not help — every first render blows it. That needs Workers Paid, which is its own decision, so this ships the half that is free.

## Design notes worth reviewing

**Validation is a substring scan, not `JSON.parse`.** The collection index is written compact, so ids appear verbatim as `"id":"fa-0"`. Measured on the largest index (Phosphor, 1 MB / 9,072 icons):

| | |
|---|---|
| `JSON.parse` | **2.9 ms** — 29% of the entire CPU budget |
| `includes()` | **0.002 ms** |

The closing quote in the needle is load-bearing: it stops `fa-0` matching `fa-0-circle`. There's a test for that.

**`?icon=` is untrusted input reflected into a card that links to rocketicons.com.** It's shape-guarded (`^[a-z0-9]+(-[a-z0-9]+)+$`, ≤64 chars) *and* verified against the index, so `?icon=free-bitcoin-click-here` cannot put that text on a rocketicons.com card. Malformed or unknown ids pass through untouched rather than erroring.

**`og:url` is rebuilt from the page's own tag**, not the request URL — otherwise a preview or `*.pages.dev` host would leak into the shared link. `canonical` is left on the collection on purpose, so 51k query variants are never indexed separately.

**`_routes.json` scopes the Worker to `/en/icons/*` and `/pt-br/icons/*`.** Everything else — every asset, doc page and OG image — is served directly and never spends an invocation. That is what keeps this inside 100k requests/day.

Bundle is **1.7 KB**, no wasm.

## Verification

`wrangler pages dev` against the real export:

| case | result |
|---|---|
| `?icon=fa-accessible-icon` | title, description, `og:url`, both alts rewritten |
| `?icon=wi-day-sunny` (pt-br) | `Day Sunny \| Weather Icons \| rocketicons` |
| no `?icon=` | untouched |
| `?icon=fa-not-a-real-icon` | untouched |
| `?icon=free-bitcoin-click-here` | untouched |
| `og:url` under a dev host | stays `https://rocketicons.com/...` |
| `/en/`, `/en/docs/`, assets, `ai/v1` | all 200, unaffected |

8 unit tests on the pure helpers; 65 tests pass overall; `next lint` clean. CI gains `test -f out/_worker.js` and `test -f out/_routes.json` so a missing bundle fails loudly instead of silently reverting to collection cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
