### PR TITLE
fix(ignition): handle generated OG manifest in tests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -89,14 +89,14 @@ jobs:
           SKIP_IGNITION_BUILD: "true"
         run: npm run build-all
 
-      - name: Test workspace
-        run: npm run test-all
-
       - name: Generate content collections
         run: npm run generate-content-collections --workspace=packages/ignition
 
       - name: Generate complete static catalog
         run: npm run generate-statics:all-icons --workspace=packages/ignition
+
+      - name: Test workspace
+        run: npm run test-all
 
       - name: Verify every generated icon and web catalog record
         run: npm run test:catalog --workspace=packages/generator

--- a/packages/ignition/src/statics-generator/og-images.test.ts
+++ b/packages/ignition/src/statics-generator/og-images.test.ts
@@ -1,8 +1,7 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, test } from "@jest/globals";
 
-import ogManifest from "@/data-helpers/og/manifest.json";
 import { AvailableLanguages } from "@/types";
 import {
   FALLBACK_OG_IMAGE,
@@ -16,7 +15,11 @@ import {
   type OgManifest
 } from "./og-manifest";
 
-const manifest = ogManifest as OgManifest;
+const manifestFile = resolve("./src/app/data-helpers/og/manifest.json");
+const hasGeneratedManifest = existsSync(manifestFile);
+const manifest = hasGeneratedManifest
+  ? (JSON.parse(readFileSync(manifestFile, "utf8")) as OgManifest)
+  : ({ pages: {}, docs: {}, collections: {} } satisfies OgManifest);
 
 const entries = [
   ...Object.values(manifest.pages),
@@ -24,7 +27,7 @@ const entries = [
   ...Object.values(manifest.collections)
 ];
 
-describe("open graph image manifest", () => {
+(hasGeneratedManifest ? describe : describe.skip)("open graph image manifest", () => {
   test("every generated entry exists on disk", () => {
     expect(entries.length).toBeGreaterThan(0);
     for (const path of entries) {
@@ -68,14 +71,12 @@ describe("open graph image manifest", () => {
       );
     }
   });
+});
 
-  test("falls back to the static hero for anything ungenerated", () => {
-    // Sampled builds (RI_GENERATE_ALL_ICONS unset) legitimately omit most collections.
-    expect(
-      lookupOgImage(manifest, "collections", ogCollectionKey("en", "not-a-collection"))
-    ).toBe(FALLBACK_OG_IMAGE);
-    expect(lookupOgImage(manifest, "pages", ogPageKey("en", "not-a-page"))).toBe(
-      FALLBACK_OG_IMAGE
-    );
-  });
+test("falls back to the static hero for anything ungenerated", () => {
+  // Sampled builds (RI_GENERATE_ALL_ICONS unset) legitimately omit most collections.
+  expect(lookupOgImage(manifest, "collections", ogCollectionKey("en", "not-a-collection"))).toBe(
+    FALLBACK_OG_IMAGE
+  );
+  expect(lookupOgImage(manifest, "pages", ogPageKey("en", "not-a-page"))).toBe(FALLBACK_OG_IMAGE);
 });


### PR DESCRIPTION
## Summary

Fixes Open Graph tests failing in clean checkouts and in the Pages workflow because the generated OG manifest did not exist when the tests started.

## Changes

- Load the generated OG manifest only when it exists.
- Skip artifact-dependent assertions when running without generated assets.
- Keep the fallback behavior test active in clean checkouts.
- Run Pages workspace tests after generating the content collections and complete static catalog.

## Validation

- All workspace tests pass.
- Ignition: 65/65 tests pass with generated artifacts.
- TypeScript checks pass.
- ESLint passes.
- `git diff --check` passes.